### PR TITLE
fix parsing of single-quoted-literal ends and add test case

### DIFF
--- a/parser/internal/dhall.go
+++ b/parser/internal/dhall.go
@@ -630,8 +630,13 @@ var g = &grammar{
 							},
 						},
 					},
+					&litMatcher{
+						pos:        position{line: 184, col: 7, offset: 4554},
+						val:        "''",
+						ignoreCase: false,
+					},
 					&seqExpr{
-						pos: position{line: 184, col: 7, offset: 4554},
+						pos: position{line: 185, col: 7, offset: 4565},
 						exprs: []interface{}{
 							&choiceExpr{
 								pos: position{line: 194, col: 6, offset: 4850},
@@ -646,7 +651,7 @@ var g = &grammar{
 									},
 									&actionExpr{
 										pos: position{line: 61, col: 14, offset: 1321},
-										run: (*parser).callonSingleQuoteContinue16,
+										run: (*parser).callonSingleQuoteContinue17,
 										expr: &litMatcher{
 											pos:        position{line: 61, col: 14, offset: 1321},
 											val:        "\r\n",
@@ -656,15 +661,10 @@ var g = &grammar{
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 184, col: 23, offset: 4570},
+								pos:  position{line: 185, col: 23, offset: 4581},
 								name: "SingleQuoteContinue",
 							},
 						},
-					},
-					&litMatcher{
-						pos:        position{line: 185, col: 7, offset: 4596},
-						val:        "''",
-						ignoreCase: false,
 					},
 				},
 			},
@@ -14101,14 +14101,14 @@ func (p *parser) callonSingleQuoteContinue10() (interface{}, error) {
 	return p.cur.onSingleQuoteContinue10()
 }
 
-func (c *current) onSingleQuoteContinue16() (interface{}, error) {
+func (c *current) onSingleQuoteContinue17() (interface{}, error) {
 	return []byte{'\n'}, nil
 }
 
-func (p *parser) callonSingleQuoteContinue16() (interface{}, error) {
+func (p *parser) callonSingleQuoteContinue17() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSingleQuoteContinue16()
+	return p.cur.onSingleQuoteContinue17()
 }
 
 func (c *current) onSingleQuoteLiteral6() (interface{}, error) {

--- a/parser/internal/dhall.peg
+++ b/parser/internal/dhall.peg
@@ -181,8 +181,8 @@ SingleQuoteContinue ←
       Interpolation SingleQuoteContinue
     / EscapedQuotePair SingleQuoteContinue
     / EscapedInterpolation SingleQuoteContinue
-    / SingleQuoteChar SingleQuoteContinue
     / "''"
+    / SingleQuoteChar SingleQuoteContinue
 
 EscapedQuotePair ← "'''" { return []byte("''"), nil }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -117,6 +117,17 @@ baz
 			TextLit{Chunks{Chunk{"foo ", TextLit{Suffix: "bar"}}},
 				"\nbaz\n"},
 		),
+		Entry("Multiple '' end correct", `
+''
+a
+''
+++
+''
+b
+''
+`,
+			Op{TextAppendOp, TextLit{Suffix: "a\n"}, TextLit{Suffix: "b\n"}},
+		),
 	)
 	DescribeTable("simple expressions", ParseAndCompare,
 		Entry("Identifier", `x`, NewVar("x")),


### PR DESCRIPTION
Behavior before the fix: 
```
dhall-golang$ echo "''\na''\n++\n''\nb''\n"| ./dhall
Text
{[] a''
++
''
b}
decoded as {Chunks:[] Suffix:a''
++
''
b}
```
With `dhall-haskell`:
```
dhall-golang$ echo "''\na''\n++\n''\nb''\n"| dhall
"ab"
```

And with the fix:
```
$ echo "''\na''\n++\n''\nb''\n"| ./dhall
Text
{[] ab}
decoded as {Chunks:[] Suffix:ab}
```

The new test case when it fails:
```
• Failure [0.001 seconds]
Expression
/home/duncan/repos/dhall-golang/parser/parser_test.go:26
  single-quoted text literals
  /home/duncan/go/pkg/mod/github.com/onsi/ginkgo@v1.7.0/extensions/table/table.go:92
    Multiple '' end correct [It]
    /home/duncan/go/pkg/mod/github.com/onsi/ginkgo@v1.7.0/extensions/table/table_entry.go:46

    Expected
        <core.TextLitTerm>: {
            Chunks: nil,
            Suffix: "a\n''\n++\n''\nb\n",
        }
    to equal
        <core.OpTerm>: {
            OpCode: 6,
            L: {Chunks: nil, Suffix: "a\n"},
            R: {Chunks: nil, Suffix: "b\n"},
        }

    /home/duncan/repos/dhall-golang/parser/parser_test.go:18
```