### PR TITLE
Generate parser from forked pigeon

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,12 @@ vendoring of dependencies is required.
 
 Dhall-golang uses [pigeon][] to generate the parser source file
 `parser/internal/dhall.go` from the PEG grammar at
-`parser/internal/dhall.peg`.  If you change the PEG grammar, you need
+`parser/internal/dhall.peg`.
+
+Note that currently the grammar is generated using a fork of pigeon;
+see https://github.com/mna/pigeon/pull/95 for details.
+
+If you change the PEG grammar, you need
 to first install the pigeon binary if you don't already have it:
 
     # either outside a module directory, or with GO111MODULE=off

--- a/parser/internal/dhall.go
+++ b/parser/internal/dhall.go
@@ -20734,6 +20734,20 @@ type litMatcher struct {
 	pos        position
 	val        string
 	ignoreCase bool
+	wantCache  string
+}
+
+func (lit *litMatcher) want() string {
+	if lit.wantCache != "" {
+		return lit.wantCache
+	}
+	ignoreCase := ""
+	if lit.ignoreCase {
+		ignoreCase = "i"
+	}
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
+	lit.wantCache = val
+	return val
 }
 
 type charClassMatcher struct {
@@ -21326,11 +21340,6 @@ func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
-	ignoreCase := ""
-	if lit.ignoreCase {
-		ignoreCase = "i"
-	}
-	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -21338,13 +21347,13 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 			cur = unicode.ToLower(cur)
 		}
 		if cur != want {
-			p.failAt(false, start.position, val)
+			p.failAt(false, start.position, lit.want())
 			p.restore(start)
 			return nil, false
 		}
 		p.read()
 	}
-	p.failAt(true, start.position, val)
+	p.failAt(true, start.position, lit.want())
 	return p.sliceFrom(start), true
 }
 


### PR DESCRIPTION
This pulls in https://github.com/mna/pigeon/pull/95 which makes the
parser significantly faster; currently the parser is the slowest part of
running the tests, and this change cuts the total test runtime from
around 42 seconds to around 26 seconds.