### PR TITLE
Use `dhall` struct tag instead of `json`

### DIFF
--- a/example_tagged_test.go
+++ b/example_tagged_test.go
@@ -8,9 +8,9 @@ import (
 
 // TaggedMessage is the struct we want to unmarshal from Dhall
 type TaggedMessage struct {
-	Name string `json:"name"`
-	Body string `json:"entity,string"`
-	Time int64  `json:"instant"`
+	Name string `dhall:"name"`
+	Body string `dhall:"entity"`
+	Time int64  `dhall:"instant"`
 }
 
 // dhallTaggedMessage is the Dhall source we want to unmarshal

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -3,7 +3,6 @@ package dhall
 import (
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/philandstuff/dhall-golang/core"
 	"github.com/philandstuff/dhall-golang/imports"
@@ -106,10 +105,7 @@ func encode(val reflect.Value, typ core.Value) core.Value {
 		for key, typ := range e {
 			structType := val.Type()
 			for i := 0; i < structType.NumField(); i++ {
-				tag := structType.Field(i).Tag.Get("json")
-				if idx := strings.Index(tag, ","); idx != -1 {
-					tag = tag[:idx]
-				}
+				tag := structType.Field(i).Tag.Get("dhall")
 				if key == tag {
 					rec[key] = encode(val.Field(i), typ)
 					continue fields
@@ -187,13 +183,7 @@ func decode(e core.Value, v reflect.Value) {
 		structType := v.Type()
 		for i := 0; i < structType.NumField(); i++ {
 			// FIXME ignores fields in RecordLit not in Struct
-			tag := structType.Field(i).Tag.Get("json")
-			if tag == "-" {
-				continue
-			}
-			if idx := strings.Index(tag, ","); idx != -1 {
-				tag = tag[:idx]
-			}
+			tag := structType.Field(i).Tag.Get("dhall")
 			if tag != "" {
 				decode(e[tag], v.Field(i))
 			} else {

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -25,7 +25,7 @@ type testStruct struct {
 }
 
 type testTaggedStruct struct {
-	Foo int `json:"baz,string"`
+	Foo int `dhall:"baz"`
 	Bar string
 }
 


### PR DESCRIPTION
I originally used `json` to try to piggyback on existing intrumented
code.  However, this is problematic if a user wants to be able to decode
as Dhall in one way but serialize as JSON in another way.

Therefore, this commit switches us to use the `dhall` tag.

Note also that `json` tags support extra metadata after a comma; we
never used that metadata but we had code to remove it.  Also `json`
supports ignoring a field completely with a tag of `"-"`.  This commit
removes all that code; `dhall` tags are just simple strings.

It's possible that in future we will still want to piggyback on `json`
tags, or add extra metadata to `dhall` tags, but for now I want to keep
dhall-golang as simple as possible and not add features until they are
demonstrably required.

Resolves #10.