### PR TITLE
Evaluate imports at import time

### DIFF
--- a/imports/imports.go
+++ b/imports/imports.go
@@ -74,6 +74,10 @@ func LoadWith(cache DhallCache, e Term, ancestors ...Fetchable) (Term, error) {
 				return nil, err
 			}
 		}
+
+		// evaluate expression
+		expr = core.Quote(core.Eval(expr))
+
 		// check hash, if supplied
 		if e.Hash != nil {
 			actualHash, err := binary.SemanticHash(expr)

--- a/imports/imports_test.go
+++ b/imports/imports_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Import resolution", func() {
 			actual, err := Load(NewEnvVarImport("FOO", Code))
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(actual).To(Equal(Annot{Expr: NaturalLit(3), Annotation: Natural}))
+			Expect(actual).To(Equal(NaturalLit(3)))
 		})
 		It("Fails to resolve code with free variables", func() {
 			os.Setenv("FOO", "x")
@@ -92,7 +92,7 @@ var _ = Describe("Import resolution", func() {
 			actual, err := Load(NewRemoteImport(server.URL()+"/foo.dhall", Code))
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(actual).To(Equal(Annot{Expr: NaturalLit(3), Annotation: Natural}))
+			Expect(actual).To(Equal(NaturalLit(3)))
 		})
 		It("Fails to resolve code with free variables", func() {
 			server.RouteToHandler("GET", "/foo.dhall",
@@ -132,7 +132,7 @@ var _ = Describe("Import resolution", func() {
 					actual, err := Load(NewRemoteImport(server.URL()+"/same-origin.dhall", Code))
 
 					Expect(err).ToNot(HaveOccurred())
-					Expect(actual).To(Equal(Annot{Expr: NaturalLit(3), Annotation: Natural}))
+					Expect(actual).To(Equal(NaturalLit(3)))
 				})
 			})
 			Context("when remote import fetches different origin", func() {
@@ -154,7 +154,7 @@ var _ = Describe("Import resolution", func() {
 					actual, err := Load(NewRemoteImport(otherOrigin.URL()+"/other-origin.dhall", Code))
 
 					Expect(err).ToNot(HaveOccurred())
-					Expect(actual).To(Equal(Annot{Expr: NaturalLit(3), Annotation: Natural}))
+					Expect(actual).To(Equal(NaturalLit(3)))
 				})
 				It("allows if Access-Control-Allow-Origin matches the Origin header", func() {
 					otherOrigin := ghttp.NewServer()
@@ -165,7 +165,7 @@ var _ = Describe("Import resolution", func() {
 					actual, err := Load(NewRemoteImport(otherOrigin.URL()+"/other-origin.dhall", Code))
 
 					Expect(err).ToNot(HaveOccurred())
-					Expect(actual).To(Equal(Annot{Expr: NaturalLit(3), Annotation: Natural}))
+					Expect(actual).To(Equal(NaturalLit(3)))
 				})
 			})
 			Context("when local import fetches remote", func() {
@@ -173,7 +173,7 @@ var _ = Describe("Import resolution", func() {
 					actual, err := Load(NewRemoteImport(server.URL()+"/no-cors.dhall", Code))
 
 					Expect(err).ToNot(HaveOccurred())
-					Expect(actual).To(Equal(Annot{Expr: NaturalLit(3), Annotation: Natural}))
+					Expect(actual).To(Equal(NaturalLit(3)))
 				})
 			})
 		})
@@ -189,7 +189,7 @@ var _ = Describe("Import resolution", func() {
 			actual, err := Load(NewLocalImport("./testdata/natural.dhall", Code))
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(actual).To(Equal(Annot{Expr: NaturalLit(3), Annotation: Natural}))
+			Expect(actual).To(Equal(NaturalLit(3)))
 		})
 		It("Fails to resolve code with free variables", func() {
 			_, err := Load(NewLocalImport("./testdata/free_variable.dhall", Code))


### PR DESCRIPTION
Also, make sure we cache the evaluated one.

(Note that, for #26, we still need to alpha-normalize before caching,
which this commit doesn't do).

See also dhall-lang/dhall-lang#933.