### PR TITLE
Check hash of expressions pulled from cache

### DIFF
--- a/imports/imports.go
+++ b/imports/imports.go
@@ -13,7 +13,11 @@ import (
 
 // Load takes a Term and resolves all imports
 func Load(e Term, ancestors ...Fetchable) (Term, error) {
-	return LoadWith(StandardCache{}, e, ancestors...)
+	cache, err := StandardCache()
+	if err != nil {
+		return nil, err
+	}
+	return LoadWith(cache, e, ancestors...)
 }
 
 // LoadWith takes a Term and resolves all imports, using cache for


### PR DESCRIPTION
The standard requires us to check the hash of expressions pulled from
the cache, and to ignore them if they don't match.

This is potentially a security feature if an adversary is able to write
bad code into the cache.

Corresponding standard test in dhall-lang/dhall-lang#983.  This change is tested against that test.