### PR TITLE
Remove misleading comment and unused rules in the parser

### DIFF
--- a/parser/internal/dhall.peg
+++ b/parser/internal/dhall.peg
@@ -233,7 +233,6 @@ Interpolation ← "${" e:CompleteExpression "}" { return e, nil }
 
 TextLiteral ← DoubleQuoteLiteral / SingleQuoteLiteral
 
-// reserved identifiers from semantics.md, only required for negative lookahed rules
 Reserved ←
     "Natural/build" { return NaturalBuild, nil }
   / "Natural/fold" { return NaturalFold, nil }
@@ -300,9 +299,7 @@ Keyword ←
   / Forall
   / with
 
-Optional ← "Optional"
 Text ← "Text"
-List ← "List"
 Location ← "Location"
 
 Combine ← "/\\" / '∧'


### PR DESCRIPTION
I'm currently porting the parser to Python (nice piece of work, here !). Here is a list of small oddities I found in the pigeon file. I don't have a functional golang install at the moment, I didn't generate the parser package after my changes, though.

- `Reserved` is actually parsed and used in `Identifier`
- `List` and `Optional` rules are never used

