### PR TITLE
support self-describing CBOR again

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/philandstuff/dhall-golang
 
 require (
-	github.com/fxamacker/cbor/v2 v2.2.0
+	github.com/fxamacker/cbor/v2 v2.2.1-0.20200511212021-28e39be4a84f
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/leanovate/gopter v0.2.5-0.20190402064358-634a59d12406
 	github.com/onsi/ginkgo v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fxamacker/cbor/v2 v2.2.0 h1:6eXqdDDe588rSYAi1HfZKbx6YYQO4mxQ9eC6xYpU/JQ=
-github.com/fxamacker/cbor/v2 v2.2.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/fxamacker/cbor/v2 v2.2.1-0.20200511212021-28e39be4a84f h1:lvGFo/tDOSQ4FKu0d2694s8XyOfAL6FLR9DCD5BIUW4=
+github.com/fxamacker/cbor/v2 v2.2.1-0.20200511212021-28e39be4a84f/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=

--- a/spec_test.go
+++ b/spec_test.go
@@ -65,9 +65,6 @@ var expectedFailures = []string{
 
 	// We don't cache the same URL within the same run
 	"TestTypeInference/CacheImports",
-
-	// self-describing cbor https://github.com/fxamacker/cbor/issues/227
-	"TestBinaryDecode/unit/SelfDescribe",
 }
 
 func pass(t *testing.T) {


### PR DESCRIPTION
Upstream has added support in master for tag 55799:
https://github.com/fxamacker/cbor/issues/227