### PR TITLE
Remove (non-functional) quoted paths in URLs

### DIFF
--- a/parser/internal/dhall.go
+++ b/parser/internal/dhall.go
@@ -2817,15 +2817,15 @@ var g = &grammar{
 		},
 		{
 			name: "Http",
-			pos:  position{line: 439, col: 1, offset: 11867},
+			pos:  position{line: 439, col: 1, offset: 11861},
 			expr: &actionExpr{
-				pos: position{line: 439, col: 8, offset: 11876},
+				pos: position{line: 439, col: 8, offset: 11870},
 				run: (*parser).callonHttp1,
 				expr: &seqExpr{
-					pos: position{line: 439, col: 8, offset: 11876},
+					pos: position{line: 439, col: 8, offset: 11870},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 439, col: 8, offset: 11876},
+							pos:   position{line: 439, col: 8, offset: 11870},
 							label: "u",
 							expr: &actionExpr{
 								pos: position{line: 405, col: 11, offset: 11058},
@@ -2855,17 +2855,17 @@ var g = &grammar{
 											want:       "\"://\"",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 409, col: 13, offset: 11210},
+											pos: position{line: 409, col: 13, offset: 11204},
 											expr: &seqExpr{
-												pos: position{line: 409, col: 14, offset: 11211},
+												pos: position{line: 409, col: 14, offset: 11205},
 												exprs: []interface{}{
 													&zeroOrMoreExpr{
-														pos: position{line: 411, col: 12, offset: 11257},
+														pos: position{line: 411, col: 12, offset: 11251},
 														expr: &choiceExpr{
-															pos: position{line: 411, col: 14, offset: 11259},
+															pos: position{line: 411, col: 14, offset: 11253},
 															alternatives: []interface{}{
 																&charClassMatcher{
-																	pos:        position{line: 435, col: 14, offset: 11789},
+																	pos:        position{line: 435, col: 14, offset: 11783},
 																	val:        "[._~-A-Za-z0-9]",
 																	chars:      []rune{'.', '_', '~', '-'},
 																	ranges:     []rune{'A', 'Z', 'a', 'z', '0', '9'},
@@ -2873,10 +2873,10 @@ var g = &grammar{
 																	inverted:   false,
 																},
 																&seqExpr{
-																	pos: position{line: 433, col: 14, offset: 11755},
+																	pos: position{line: 433, col: 14, offset: 11749},
 																	exprs: []interface{}{
 																		&litMatcher{
-																			pos:        position{line: 433, col: 14, offset: 11755},
+																			pos:        position{line: 433, col: 14, offset: 11749},
 																			val:        "%",
 																			ignoreCase: false,
 																			want:       "\"%\"",
@@ -2922,7 +2922,7 @@ var g = &grammar{
 																	},
 																},
 																&charClassMatcher{
-																	pos:        position{line: 437, col: 13, offset: 11820},
+																	pos:        position{line: 437, col: 13, offset: 11814},
 																	val:        "[!$&\\*+;=:]",
 																	chars:      []rune{'!', '$', '&', '\'', '*', '+', ';', '=', ':'},
 																	ignoreCase: false,
@@ -2932,7 +2932,7 @@ var g = &grammar{
 														},
 													},
 													&litMatcher{
-														pos:        position{line: 409, col: 23, offset: 11220},
+														pos:        position{line: 409, col: 23, offset: 11214},
 														val:        "@",
 														ignoreCase: false,
 														want:       "\"@\"",
@@ -2941,25 +2941,25 @@ var g = &grammar{
 											},
 										},
 										&choiceExpr{
-											pos: position{line: 413, col: 8, offset: 11314},
+											pos: position{line: 413, col: 8, offset: 11308},
 											alternatives: []interface{}{
 												&seqExpr{
-													pos: position{line: 417, col: 13, offset: 11366},
+													pos: position{line: 417, col: 13, offset: 11360},
 													exprs: []interface{}{
 														&litMatcher{
-															pos:        position{line: 417, col: 13, offset: 11366},
+															pos:        position{line: 417, col: 13, offset: 11360},
 															val:        "[",
 															ignoreCase: false,
 															want:       "\"[\"",
 														},
 														&actionExpr{
-															pos: position{line: 419, col: 15, offset: 11403},
+															pos: position{line: 419, col: 15, offset: 11397},
 															run: (*parser).callonHttp28,
 															expr: &seqExpr{
-																pos: position{line: 419, col: 15, offset: 11403},
+																pos: position{line: 419, col: 15, offset: 11397},
 																exprs: []interface{}{
 																	&zeroOrMoreExpr{
-																		pos: position{line: 419, col: 15, offset: 11403},
+																		pos: position{line: 419, col: 15, offset: 11397},
 																		expr: &choiceExpr{
 																			pos: position{line: 133, col: 10, offset: 3106},
 																			alternatives: []interface{}{
@@ -2981,15 +2981,15 @@ var g = &grammar{
 																		},
 																	},
 																	&litMatcher{
-																		pos:        position{line: 419, col: 25, offset: 11413},
+																		pos:        position{line: 419, col: 25, offset: 11407},
 																		val:        ":",
 																		ignoreCase: false,
 																		want:       "\":\"",
 																	},
 																	&zeroOrMoreExpr{
-																		pos: position{line: 419, col: 29, offset: 11417},
+																		pos: position{line: 419, col: 29, offset: 11411},
 																		expr: &choiceExpr{
-																			pos: position{line: 419, col: 30, offset: 11418},
+																			pos: position{line: 419, col: 30, offset: 11412},
 																			alternatives: []interface{}{
 																				&charClassMatcher{
 																					pos:        position{line: 131, col: 9, offset: 3088},
@@ -3006,7 +3006,7 @@ var g = &grammar{
 																					inverted:   false,
 																				},
 																				&charClassMatcher{
-																					pos:        position{line: 419, col: 39, offset: 11427},
+																					pos:        position{line: 419, col: 39, offset: 11421},
 																					val:        "[:.]",
 																					chars:      []rune{':', '.'},
 																					ignoreCase: false,
@@ -3019,7 +3019,7 @@ var g = &grammar{
 															},
 														},
 														&litMatcher{
-															pos:        position{line: 417, col: 29, offset: 11382},
+															pos:        position{line: 417, col: 29, offset: 11376},
 															val:        "]",
 															ignoreCase: false,
 															want:       "\"]\"",
@@ -3027,12 +3027,12 @@ var g = &grammar{
 													},
 												},
 												&zeroOrMoreExpr{
-													pos: position{line: 425, col: 11, offset: 11599},
+													pos: position{line: 425, col: 11, offset: 11593},
 													expr: &choiceExpr{
-														pos: position{line: 425, col: 12, offset: 11600},
+														pos: position{line: 425, col: 12, offset: 11594},
 														alternatives: []interface{}{
 															&charClassMatcher{
-																pos:        position{line: 435, col: 14, offset: 11789},
+																pos:        position{line: 435, col: 14, offset: 11783},
 																val:        "[._~-A-Za-z0-9]",
 																chars:      []rune{'.', '_', '~', '-'},
 																ranges:     []rune{'A', 'Z', 'a', 'z', '0', '9'},
@@ -3040,10 +3040,10 @@ var g = &grammar{
 																inverted:   false,
 															},
 															&seqExpr{
-																pos: position{line: 433, col: 14, offset: 11755},
+																pos: position{line: 433, col: 14, offset: 11749},
 																exprs: []interface{}{
 																	&litMatcher{
-																		pos:        position{line: 433, col: 14, offset: 11755},
+																		pos:        position{line: 433, col: 14, offset: 11749},
 																		val:        "%",
 																		ignoreCase: false,
 																		want:       "\"%\"",
@@ -3089,7 +3089,7 @@ var g = &grammar{
 																},
 															},
 															&charClassMatcher{
-																pos:        position{line: 437, col: 13, offset: 11820},
+																pos:        position{line: 437, col: 13, offset: 11814},
 																val:        "[!$&\\*+;=]",
 																chars:      []rune{'!', '$', '&', '\'', '*', '+', ';', '='},
 																ignoreCase: false,
@@ -3101,18 +3101,18 @@ var g = &grammar{
 											},
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 409, col: 34, offset: 11231},
+											pos: position{line: 409, col: 34, offset: 11225},
 											expr: &seqExpr{
-												pos: position{line: 409, col: 35, offset: 11232},
+												pos: position{line: 409, col: 35, offset: 11226},
 												exprs: []interface{}{
 													&litMatcher{
-														pos:        position{line: 409, col: 35, offset: 11232},
+														pos:        position{line: 409, col: 35, offset: 11226},
 														val:        ":",
 														ignoreCase: false,
 														want:       "\":\"",
 													},
 													&zeroOrMoreExpr{
-														pos: position{line: 415, col: 8, offset: 11344},
+														pos: position{line: 415, col: 8, offset: 11338},
 														expr: &charClassMatcher{
 															pos:        position{line: 131, col: 9, offset: 3088},
 															val:        "[0-9]",
@@ -3125,188 +3125,23 @@ var g = &grammar{
 											},
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 407, col: 11, offset: 11164},
-											expr: &choiceExpr{
-												pos: position{line: 407, col: 12, offset: 11165},
-												alternatives: []interface{}{
-													&actionExpr{
-														pos: position{line: 384, col: 17, offset: 10261},
-														run: (*parser).callonHttp60,
-														expr: &seqExpr{
-															pos: position{line: 384, col: 17, offset: 10261},
-															exprs: []interface{}{
-																&litMatcher{
-																	pos:        position{line: 384, col: 17, offset: 10261},
-																	val:        "/",
-																	ignoreCase: false,
-																	want:       "\"/\"",
-																},
-																&labeledExpr{
-																	pos:   position{line: 384, col: 21, offset: 10265},
-																	label: "u",
-																	expr: &actionExpr{
-																		pos: position{line: 381, col: 25, offset: 10120},
-																		run: (*parser).callonHttp64,
-																		expr: &oneOrMoreExpr{
-																			pos: position{line: 381, col: 25, offset: 10120},
-																			expr: &charClassMatcher{
-																				pos:        position{line: 365, col: 6, offset: 9865},
-																				val:        "[!=|~$-\\*-+--.0-;@-Z^-z]",
-																				chars:      []rune{'!', '=', '|', '~'},
-																				ranges:     []rune{'$', '\'', '*', '+', '-', '.', '0', ';', '@', 'Z', '^', 'z'},
-																				ignoreCase: false,
-																				inverted:   false,
-																			},
-																		},
-																	},
-																},
-															},
-														},
-													},
-													&actionExpr{
-														pos: position{line: 385, col: 17, offset: 10323},
-														run: (*parser).callonHttp67,
-														expr: &seqExpr{
-															pos: position{line: 385, col: 17, offset: 10323},
-															exprs: []interface{}{
-																&litMatcher{
-																	pos:        position{line: 385, col: 17, offset: 10323},
-																	val:        "/\"",
-																	ignoreCase: false,
-																	want:       "\"/\\\"\"",
-																},
-																&labeledExpr{
-																	pos:   position{line: 385, col: 25, offset: 10331},
-																	label: "q",
-																	expr: &actionExpr{
-																		pos: position{line: 382, col: 23, offset: 10190},
-																		run: (*parser).callonHttp71,
-																		expr: &oneOrMoreExpr{
-																			pos: position{line: 382, col: 23, offset: 10190},
-																			expr: &charClassMatcher{
-																				pos:        position{line: 376, col: 6, offset: 10028},
-																				val:        "[𐀀D -!#-.0-\\u007f\\u0080-\\ud7ff\\ue000-�𐀀-\\U0001fffd𠀀-\\U0002fffd\\U00030000-\\U0003fffd\\U00040000-\\U0004fffd\\U00050000-\\U0005fffd\\U00060000-\\U0006fffd\\U00070000-\\U0007fffd\\U00080000-\\U0008fffd\\U00090000-\\U0009fffd\\U000a0000-\\U000afffd\\U000b0000-\\U000bfffd\\U000c0000-\\U000cfffd\\U000d0000-\\U000dfffd\\U000e0000-\\U000efffd\\U000f0000-\\U000ffffd0-\\U00010fff]",
-																				chars:      []rune{'𐀀', 'D'},
-																				ranges:     []rune{' ', '!', '#', '.', '0', '\u007f', '\u0080', '\ud7ff', '\ue000', '�', '𐀀', '\U0001fffd', '𠀀', '\U0002fffd', '\U00030000', '\U0003fffd', '\U00040000', '\U0004fffd', '\U00050000', '\U0005fffd', '\U00060000', '\U0006fffd', '\U00070000', '\U0007fffd', '\U00080000', '\U0008fffd', '\U00090000', '\U0009fffd', '\U000a0000', '\U000afffd', '\U000b0000', '\U000bfffd', '\U000c0000', '\U000cfffd', '\U000d0000', '\U000dfffd', '\U000e0000', '\U000efffd', '\U000f0000', '\U000ffffd', '0', '\U00010fff'},
-																				ignoreCase: false,
-																				inverted:   false,
-																			},
-																		},
-																	},
-																},
-																&litMatcher{
-																	pos:        position{line: 385, col: 47, offset: 10353},
-																	val:        "\"",
-																	ignoreCase: false,
-																	want:       "\"\\\"\"",
-																},
-															},
-														},
-													},
-													&seqExpr{
-														pos: position{line: 407, col: 28, offset: 11181},
-														exprs: []interface{}{
-															&litMatcher{
-																pos:        position{line: 407, col: 28, offset: 11181},
-																val:        "/",
-																ignoreCase: false,
-																want:       "\"/\"",
-															},
-															&zeroOrMoreExpr{
-																pos: position{line: 427, col: 11, offset: 11651},
-																expr: &choiceExpr{
-																	pos: position{line: 429, col: 9, offset: 11669},
-																	alternatives: []interface{}{
-																		&charClassMatcher{
-																			pos:        position{line: 435, col: 14, offset: 11789},
-																			val:        "[._~-A-Za-z0-9]",
-																			chars:      []rune{'.', '_', '~', '-'},
-																			ranges:     []rune{'A', 'Z', 'a', 'z', '0', '9'},
-																			ignoreCase: false,
-																			inverted:   false,
-																		},
-																		&seqExpr{
-																			pos: position{line: 433, col: 14, offset: 11755},
-																			exprs: []interface{}{
-																				&litMatcher{
-																					pos:        position{line: 433, col: 14, offset: 11755},
-																					val:        "%",
-																					ignoreCase: false,
-																					want:       "\"%\"",
-																				},
-																				&choiceExpr{
-																					pos: position{line: 133, col: 10, offset: 3106},
-																					alternatives: []interface{}{
-																						&charClassMatcher{
-																							pos:        position{line: 131, col: 9, offset: 3088},
-																							val:        "[0-9]",
-																							ranges:     []rune{'0', '9'},
-																							ignoreCase: false,
-																							inverted:   false,
-																						},
-																						&charClassMatcher{
-																							pos:        position{line: 133, col: 18, offset: 3114},
-																							val:        "[a-f]i",
-																							ranges:     []rune{'a', 'f'},
-																							ignoreCase: true,
-																							inverted:   false,
-																						},
-																					},
-																				},
-																				&choiceExpr{
-																					pos: position{line: 133, col: 10, offset: 3106},
-																					alternatives: []interface{}{
-																						&charClassMatcher{
-																							pos:        position{line: 131, col: 9, offset: 3088},
-																							val:        "[0-9]",
-																							ranges:     []rune{'0', '9'},
-																							ignoreCase: false,
-																							inverted:   false,
-																						},
-																						&charClassMatcher{
-																							pos:        position{line: 133, col: 18, offset: 3114},
-																							val:        "[a-f]i",
-																							ranges:     []rune{'a', 'f'},
-																							ignoreCase: true,
-																							inverted:   false,
-																						},
-																					},
-																				},
-																			},
-																		},
-																		&charClassMatcher{
-																			pos:        position{line: 437, col: 13, offset: 11820},
-																			val:        "[!$&\\*+;=:@]",
-																			chars:      []rune{'!', '$', '&', '\'', '*', '+', ';', '=', ':', '@'},
-																			ignoreCase: false,
-																			inverted:   false,
-																		},
-																	},
-																},
-															},
-														},
-													},
-												},
-											},
-										},
-										&zeroOrOneExpr{
-											pos: position{line: 405, col: 42, offset: 11089},
+											pos: position{line: 407, col: 16, offset: 11174},
 											expr: &seqExpr{
-												pos: position{line: 405, col: 44, offset: 11091},
+												pos: position{line: 407, col: 17, offset: 11175},
 												exprs: []interface{}{
 													&litMatcher{
-														pos:        position{line: 405, col: 44, offset: 11091},
-														val:        "?",
+														pos:        position{line: 407, col: 17, offset: 11175},
+														val:        "/",
 														ignoreCase: false,
-														want:       "\"?\"",
+														want:       "\"/\"",
 													},
 													&zeroOrMoreExpr{
-														pos: position{line: 431, col: 9, offset: 11723},
+														pos: position{line: 427, col: 11, offset: 11645},
 														expr: &choiceExpr{
-															pos: position{line: 431, col: 10, offset: 11724},
+															pos: position{line: 429, col: 9, offset: 11663},
 															alternatives: []interface{}{
 																&charClassMatcher{
-																	pos:        position{line: 435, col: 14, offset: 11789},
+																	pos:        position{line: 435, col: 14, offset: 11783},
 																	val:        "[._~-A-Za-z0-9]",
 																	chars:      []rune{'.', '_', '~', '-'},
 																	ranges:     []rune{'A', 'Z', 'a', 'z', '0', '9'},
@@ -3314,10 +3149,10 @@ var g = &grammar{
 																	inverted:   false,
 																},
 																&seqExpr{
-																	pos: position{line: 433, col: 14, offset: 11755},
+																	pos: position{line: 433, col: 14, offset: 11749},
 																	exprs: []interface{}{
 																		&litMatcher{
-																			pos:        position{line: 433, col: 14, offset: 11755},
+																			pos:        position{line: 433, col: 14, offset: 11749},
 																			val:        "%",
 																			ignoreCase: false,
 																			want:       "\"%\"",
@@ -3363,7 +3198,93 @@ var g = &grammar{
 																	},
 																},
 																&charClassMatcher{
-																	pos:        position{line: 437, col: 13, offset: 11820},
+																	pos:        position{line: 437, col: 13, offset: 11814},
+																	val:        "[!$&\\*+;=:@]",
+																	chars:      []rune{'!', '$', '&', '\'', '*', '+', ';', '=', ':', '@'},
+																	ignoreCase: false,
+																	inverted:   false,
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+										&zeroOrOneExpr{
+											pos: position{line: 405, col: 47, offset: 11094},
+											expr: &seqExpr{
+												pos: position{line: 405, col: 49, offset: 11096},
+												exprs: []interface{}{
+													&litMatcher{
+														pos:        position{line: 405, col: 49, offset: 11096},
+														val:        "?",
+														ignoreCase: false,
+														want:       "\"?\"",
+													},
+													&zeroOrMoreExpr{
+														pos: position{line: 431, col: 9, offset: 11717},
+														expr: &choiceExpr{
+															pos: position{line: 431, col: 10, offset: 11718},
+															alternatives: []interface{}{
+																&charClassMatcher{
+																	pos:        position{line: 435, col: 14, offset: 11783},
+																	val:        "[._~-A-Za-z0-9]",
+																	chars:      []rune{'.', '_', '~', '-'},
+																	ranges:     []rune{'A', 'Z', 'a', 'z', '0', '9'},
+																	ignoreCase: false,
+																	inverted:   false,
+																},
+																&seqExpr{
+																	pos: position{line: 433, col: 14, offset: 11749},
+																	exprs: []interface{}{
+																		&litMatcher{
+																			pos:        position{line: 433, col: 14, offset: 11749},
+																			val:        "%",
+																			ignoreCase: false,
+																			want:       "\"%\"",
+																		},
+																		&choiceExpr{
+																			pos: position{line: 133, col: 10, offset: 3106},
+																			alternatives: []interface{}{
+																				&charClassMatcher{
+																					pos:        position{line: 131, col: 9, offset: 3088},
+																					val:        "[0-9]",
+																					ranges:     []rune{'0', '9'},
+																					ignoreCase: false,
+																					inverted:   false,
+																				},
+																				&charClassMatcher{
+																					pos:        position{line: 133, col: 18, offset: 3114},
+																					val:        "[a-f]i",
+																					ranges:     []rune{'a', 'f'},
+																					ignoreCase: true,
+																					inverted:   false,
+																				},
+																			},
+																		},
+																		&choiceExpr{
+																			pos: position{line: 133, col: 10, offset: 3106},
+																			alternatives: []interface{}{
+																				&charClassMatcher{
+																					pos:        position{line: 131, col: 9, offset: 3088},
+																					val:        "[0-9]",
+																					ranges:     []rune{'0', '9'},
+																					ignoreCase: false,
+																					inverted:   false,
+																				},
+																				&charClassMatcher{
+																					pos:        position{line: 133, col: 18, offset: 3114},
+																					val:        "[a-f]i",
+																					ranges:     []rune{'a', 'f'},
+																					ignoreCase: true,
+																					inverted:   false,
+																				},
+																			},
+																		},
+																	},
+																},
+																&charClassMatcher{
+																	pos:        position{line: 437, col: 13, offset: 11814},
 																	val:        "[!$&\\*+;=:@/?]",
 																	chars:      []rune{'!', '$', '&', '\'', '*', '+', ';', '=', ':', '@', '/', '?'},
 																	ignoreCase: false,
@@ -3380,15 +3301,15 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 439, col: 18, offset: 11886},
+							pos:   position{line: 439, col: 18, offset: 11880},
 							label: "usingClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 439, col: 30, offset: 11898},
+								pos: position{line: 439, col: 30, offset: 11892},
 								expr: &seqExpr{
-									pos: position{line: 439, col: 32, offset: 11900},
+									pos: position{line: 439, col: 32, offset: 11894},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 439, col: 32, offset: 11900},
+											pos:  position{line: 439, col: 32, offset: 11894},
 											name: "_",
 										},
 										&litMatcher{
@@ -3398,11 +3319,11 @@ var g = &grammar{
 											want:       "\"using\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 439, col: 40, offset: 11908},
+											pos:  position{line: 439, col: 40, offset: 11902},
 											name: "_1",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 439, col: 43, offset: 11911},
+											pos:  position{line: 439, col: 43, offset: 11905},
 											name: "ImportExpression",
 										},
 									},
@@ -3415,9 +3336,9 @@ var g = &grammar{
 		},
 		{
 			name: "ImportType",
-			pos:  position{line: 480, col: 1, offset: 13107},
+			pos:  position{line: 480, col: 1, offset: 13101},
 			expr: &choiceExpr{
-				pos: position{line: 480, col: 14, offset: 13122},
+				pos: position{line: 480, col: 14, offset: 13116},
 				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 254, col: 11, offset: 6455},
@@ -3871,35 +3792,35 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 480, col: 32, offset: 13140},
+						pos:  position{line: 480, col: 32, offset: 13134},
 						name: "Http",
 					},
 					&actionExpr{
-						pos: position{line: 446, col: 7, offset: 12119},
+						pos: position{line: 446, col: 7, offset: 12113},
 						run: (*parser).callonImportType98,
 						expr: &seqExpr{
-							pos: position{line: 446, col: 7, offset: 12119},
+							pos: position{line: 446, col: 7, offset: 12113},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 446, col: 7, offset: 12119},
+									pos:        position{line: 446, col: 7, offset: 12113},
 									val:        "env:",
 									ignoreCase: false,
 									want:       "\"env:\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 446, col: 14, offset: 12126},
+									pos:   position{line: 446, col: 14, offset: 12120},
 									label: "v",
 									expr: &choiceExpr{
-										pos: position{line: 446, col: 17, offset: 12129},
+										pos: position{line: 446, col: 17, offset: 12123},
 										alternatives: []interface{}{
 											&actionExpr{
-												pos: position{line: 448, col: 27, offset: 12228},
+												pos: position{line: 448, col: 27, offset: 12222},
 												run: (*parser).callonImportType103,
 												expr: &seqExpr{
-													pos: position{line: 448, col: 27, offset: 12228},
+													pos: position{line: 448, col: 27, offset: 12222},
 													exprs: []interface{}{
 														&charClassMatcher{
-															pos:        position{line: 448, col: 27, offset: 12228},
+															pos:        position{line: 448, col: 27, offset: 12222},
 															val:        "[_A-Za-z]",
 															chars:      []rune{'_'},
 															ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -3907,9 +3828,9 @@ var g = &grammar{
 															inverted:   false,
 														},
 														&zeroOrMoreExpr{
-															pos: position{line: 448, col: 36, offset: 12237},
+															pos: position{line: 448, col: 36, offset: 12231},
 															expr: &charClassMatcher{
-																pos:        position{line: 448, col: 36, offset: 12237},
+																pos:        position{line: 448, col: 36, offset: 12231},
 																val:        "[_A-Za-z0-9]",
 																chars:      []rune{'_'},
 																ranges:     []rune{'A', 'Z', 'a', 'z', '0', '9'},
@@ -3921,123 +3842,123 @@ var g = &grammar{
 												},
 											},
 											&actionExpr{
-												pos: position{line: 452, col: 28, offset: 12322},
+												pos: position{line: 452, col: 28, offset: 12316},
 												run: (*parser).callonImportType108,
 												expr: &seqExpr{
-													pos: position{line: 452, col: 28, offset: 12322},
+													pos: position{line: 452, col: 28, offset: 12316},
 													exprs: []interface{}{
 														&litMatcher{
-															pos:        position{line: 452, col: 28, offset: 12322},
+															pos:        position{line: 452, col: 28, offset: 12316},
 															val:        "\"",
 															ignoreCase: false,
 															want:       "\"\\\"\"",
 														},
 														&labeledExpr{
-															pos:   position{line: 452, col: 32, offset: 12326},
+															pos:   position{line: 452, col: 32, offset: 12320},
 															label: "v",
 															expr: &actionExpr{
-																pos: position{line: 456, col: 35, offset: 12421},
+																pos: position{line: 456, col: 35, offset: 12415},
 																run: (*parser).callonImportType112,
 																expr: &labeledExpr{
-																	pos:   position{line: 456, col: 35, offset: 12421},
+																	pos:   position{line: 456, col: 35, offset: 12415},
 																	label: "v",
 																	expr: &oneOrMoreExpr{
-																		pos: position{line: 456, col: 37, offset: 12423},
+																		pos: position{line: 456, col: 37, offset: 12417},
 																		expr: &choiceExpr{
-																			pos: position{line: 466, col: 7, offset: 12680},
+																			pos: position{line: 466, col: 7, offset: 12674},
 																			alternatives: []interface{}{
 																				&actionExpr{
-																					pos: position{line: 466, col: 7, offset: 12680},
+																					pos: position{line: 466, col: 7, offset: 12674},
 																					run: (*parser).callonImportType116,
 																					expr: &litMatcher{
-																						pos:        position{line: 466, col: 7, offset: 12680},
+																						pos:        position{line: 466, col: 7, offset: 12674},
 																						val:        "\\\"",
 																						ignoreCase: false,
 																						want:       "\"\\\\\\\"\"",
 																					},
 																				},
 																				&actionExpr{
-																					pos: position{line: 467, col: 7, offset: 12720},
+																					pos: position{line: 467, col: 7, offset: 12714},
 																					run: (*parser).callonImportType118,
 																					expr: &litMatcher{
-																						pos:        position{line: 467, col: 7, offset: 12720},
+																						pos:        position{line: 467, col: 7, offset: 12714},
 																						val:        "\\\\",
 																						ignoreCase: false,
 																						want:       "\"\\\\\\\\\"",
 																					},
 																				},
 																				&actionExpr{
-																					pos: position{line: 468, col: 7, offset: 12760},
+																					pos: position{line: 468, col: 7, offset: 12754},
 																					run: (*parser).callonImportType120,
 																					expr: &litMatcher{
-																						pos:        position{line: 468, col: 7, offset: 12760},
+																						pos:        position{line: 468, col: 7, offset: 12754},
 																						val:        "\\a",
 																						ignoreCase: false,
 																						want:       "\"\\\\a\"",
 																					},
 																				},
 																				&actionExpr{
-																					pos: position{line: 469, col: 7, offset: 12800},
+																					pos: position{line: 469, col: 7, offset: 12794},
 																					run: (*parser).callonImportType122,
 																					expr: &litMatcher{
-																						pos:        position{line: 469, col: 7, offset: 12800},
+																						pos:        position{line: 469, col: 7, offset: 12794},
 																						val:        "\\b",
 																						ignoreCase: false,
 																						want:       "\"\\\\b\"",
 																					},
 																				},
 																				&actionExpr{
-																					pos: position{line: 470, col: 7, offset: 12840},
+																					pos: position{line: 470, col: 7, offset: 12834},
 																					run: (*parser).callonImportType124,
 																					expr: &litMatcher{
-																						pos:        position{line: 470, col: 7, offset: 12840},
+																						pos:        position{line: 470, col: 7, offset: 12834},
 																						val:        "\\f",
 																						ignoreCase: false,
 																						want:       "\"\\\\f\"",
 																					},
 																				},
 																				&actionExpr{
-																					pos: position{line: 471, col: 7, offset: 12880},
+																					pos: position{line: 471, col: 7, offset: 12874},
 																					run: (*parser).callonImportType126,
 																					expr: &litMatcher{
-																						pos:        position{line: 471, col: 7, offset: 12880},
+																						pos:        position{line: 471, col: 7, offset: 12874},
 																						val:        "\\n",
 																						ignoreCase: false,
 																						want:       "\"\\\\n\"",
 																					},
 																				},
 																				&actionExpr{
-																					pos: position{line: 472, col: 7, offset: 12920},
+																					pos: position{line: 472, col: 7, offset: 12914},
 																					run: (*parser).callonImportType128,
 																					expr: &litMatcher{
-																						pos:        position{line: 472, col: 7, offset: 12920},
+																						pos:        position{line: 472, col: 7, offset: 12914},
 																						val:        "\\r",
 																						ignoreCase: false,
 																						want:       "\"\\\\r\"",
 																					},
 																				},
 																				&actionExpr{
-																					pos: position{line: 473, col: 7, offset: 12960},
+																					pos: position{line: 473, col: 7, offset: 12954},
 																					run: (*parser).callonImportType130,
 																					expr: &litMatcher{
-																						pos:        position{line: 473, col: 7, offset: 12960},
+																						pos:        position{line: 473, col: 7, offset: 12954},
 																						val:        "\\t",
 																						ignoreCase: false,
 																						want:       "\"\\\\t\"",
 																					},
 																				},
 																				&actionExpr{
-																					pos: position{line: 474, col: 7, offset: 13000},
+																					pos: position{line: 474, col: 7, offset: 12994},
 																					run: (*parser).callonImportType132,
 																					expr: &litMatcher{
-																						pos:        position{line: 474, col: 7, offset: 13000},
+																						pos:        position{line: 474, col: 7, offset: 12994},
 																						val:        "\\v",
 																						ignoreCase: false,
 																						want:       "\"\\\\v\"",
 																					},
 																				},
 																				&charClassMatcher{
-																					pos:        position{line: 475, col: 7, offset: 13040},
+																					pos:        position{line: 475, col: 7, offset: 13034},
 																					val:        "[ -!#-<>-[]-~]",
 																					ranges:     []rune{' ', '!', '#', '<', '>', '[', ']', '~'},
 																					ignoreCase: false,
@@ -4050,7 +3971,7 @@ var g = &grammar{
 															},
 														},
 														&litMatcher{
-															pos:        position{line: 452, col: 66, offset: 12360},
+															pos:        position{line: 452, col: 66, offset: 12354},
 															val:        "\"",
 															ignoreCase: false,
 															want:       "\"\\\"\"",
@@ -4069,53 +3990,53 @@ var g = &grammar{
 		},
 		{
 			name: "ImportHashed",
-			pos:  position{line: 498, col: 1, offset: 13992},
+			pos:  position{line: 498, col: 1, offset: 13986},
 			expr: &actionExpr{
-				pos: position{line: 498, col: 16, offset: 14009},
+				pos: position{line: 498, col: 16, offset: 14003},
 				run: (*parser).callonImportHashed1,
 				expr: &seqExpr{
-					pos: position{line: 498, col: 16, offset: 14009},
+					pos: position{line: 498, col: 16, offset: 14003},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 498, col: 16, offset: 14009},
+							pos:   position{line: 498, col: 16, offset: 14003},
 							label: "i",
 							expr: &ruleRefExpr{
-								pos:  position{line: 498, col: 18, offset: 14011},
+								pos:  position{line: 498, col: 18, offset: 14005},
 								name: "ImportType",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 498, col: 29, offset: 14022},
+							pos:   position{line: 498, col: 29, offset: 14016},
 							label: "h",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 498, col: 31, offset: 14024},
+								pos: position{line: 498, col: 31, offset: 14018},
 								expr: &seqExpr{
-									pos: position{line: 498, col: 32, offset: 14025},
+									pos: position{line: 498, col: 32, offset: 14019},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 498, col: 32, offset: 14025},
+											pos:  position{line: 498, col: 32, offset: 14019},
 											name: "_1",
 										},
 										&actionExpr{
-											pos: position{line: 496, col: 8, offset: 13908},
+											pos: position{line: 496, col: 8, offset: 13902},
 											run: (*parser).callonImportHashed9,
 											expr: &seqExpr{
-												pos: position{line: 496, col: 8, offset: 13908},
+												pos: position{line: 496, col: 8, offset: 13902},
 												exprs: []interface{}{
 													&litMatcher{
-														pos:        position{line: 496, col: 8, offset: 13908},
+														pos:        position{line: 496, col: 8, offset: 13902},
 														val:        "sha256:",
 														ignoreCase: false,
 														want:       "\"sha256:\"",
 													},
 													&labeledExpr{
-														pos:   position{line: 496, col: 18, offset: 13918},
+														pos:   position{line: 496, col: 18, offset: 13912},
 														label: "val",
 														expr: &actionExpr{
-															pos: position{line: 483, col: 13, offset: 13232},
+															pos: position{line: 483, col: 13, offset: 13226},
 															run: (*parser).callonImportHashed13,
 															expr: &seqExpr{
-																pos: position{line: 483, col: 13, offset: 13232},
+																pos: position{line: 483, col: 13, offset: 13226},
 																exprs: []interface{}{
 																	&choiceExpr{
 																		pos: position{line: 133, col: 10, offset: 3106},
@@ -5350,26 +5271,26 @@ var g = &grammar{
 		},
 		{
 			name: "Import",
-			pos:  position{line: 506, col: 1, offset: 14183},
+			pos:  position{line: 506, col: 1, offset: 14177},
 			expr: &choiceExpr{
-				pos: position{line: 506, col: 10, offset: 14194},
+				pos: position{line: 506, col: 10, offset: 14188},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 506, col: 10, offset: 14194},
+						pos: position{line: 506, col: 10, offset: 14188},
 						run: (*parser).callonImport2,
 						expr: &seqExpr{
-							pos: position{line: 506, col: 10, offset: 14194},
+							pos: position{line: 506, col: 10, offset: 14188},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 506, col: 10, offset: 14194},
+									pos:   position{line: 506, col: 10, offset: 14188},
 									label: "i",
 									expr: &ruleRefExpr{
-										pos:  position{line: 506, col: 12, offset: 14196},
+										pos:  position{line: 506, col: 12, offset: 14190},
 										name: "ImportHashed",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 506, col: 25, offset: 14209},
+									pos:  position{line: 506, col: 25, offset: 14203},
 									name: "_",
 								},
 								&litMatcher{
@@ -5379,7 +5300,7 @@ var g = &grammar{
 									want:       "\"as\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 506, col: 30, offset: 14214},
+									pos:  position{line: 506, col: 30, offset: 14208},
 									name: "_1",
 								},
 								&litMatcher{
@@ -5392,21 +5313,21 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 507, col: 10, offset: 14307},
+						pos: position{line: 507, col: 10, offset: 14301},
 						run: (*parser).callonImport10,
 						expr: &seqExpr{
-							pos: position{line: 507, col: 10, offset: 14307},
+							pos: position{line: 507, col: 10, offset: 14301},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 507, col: 10, offset: 14307},
+									pos:   position{line: 507, col: 10, offset: 14301},
 									label: "i",
 									expr: &ruleRefExpr{
-										pos:  position{line: 507, col: 12, offset: 14309},
+										pos:  position{line: 507, col: 12, offset: 14303},
 										name: "ImportHashed",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 507, col: 25, offset: 14322},
+									pos:  position{line: 507, col: 25, offset: 14316},
 									name: "_",
 								},
 								&litMatcher{
@@ -5416,7 +5337,7 @@ var g = &grammar{
 									want:       "\"as\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 507, col: 30, offset: 14327},
+									pos:  position{line: 507, col: 30, offset: 14321},
 									name: "_1",
 								},
 								&litMatcher{
@@ -5429,13 +5350,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 508, col: 10, offset: 14425},
+						pos: position{line: 508, col: 10, offset: 14419},
 						run: (*parser).callonImport18,
 						expr: &labeledExpr{
-							pos:   position{line: 508, col: 10, offset: 14425},
+							pos:   position{line: 508, col: 10, offset: 14419},
 							label: "i",
 							expr: &ruleRefExpr{
-								pos:  position{line: 508, col: 12, offset: 14427},
+								pos:  position{line: 508, col: 12, offset: 14421},
 								name: "ImportHashed",
 							},
 						},
@@ -5445,12 +5366,12 @@ var g = &grammar{
 		},
 		{
 			name: "LetBinding",
-			pos:  position{line: 511, col: 1, offset: 14515},
+			pos:  position{line: 511, col: 1, offset: 14509},
 			expr: &actionExpr{
-				pos: position{line: 511, col: 14, offset: 14530},
+				pos: position{line: 511, col: 14, offset: 14524},
 				run: (*parser).callonLetBinding1,
 				expr: &seqExpr{
-					pos: position{line: 511, col: 14, offset: 14530},
+					pos: position{line: 511, col: 14, offset: 14524},
 					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 249, col: 7, offset: 6377},
@@ -5459,11 +5380,11 @@ var g = &grammar{
 							want:       "\"let\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 511, col: 18, offset: 14534},
+							pos:  position{line: 511, col: 18, offset: 14528},
 							name: "_1",
 						},
 						&labeledExpr{
-							pos:   position{line: 511, col: 21, offset: 14537},
+							pos:   position{line: 511, col: 21, offset: 14531},
 							label: "label",
 							expr: &choiceExpr{
 								pos: position{line: 149, col: 20, offset: 3633},
@@ -6971,23 +6892,23 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 511, col: 44, offset: 14560},
+							pos:  position{line: 511, col: 44, offset: 14554},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 511, col: 46, offset: 14562},
+							pos:   position{line: 511, col: 46, offset: 14556},
 							label: "a",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 511, col: 48, offset: 14564},
+								pos: position{line: 511, col: 48, offset: 14558},
 								expr: &seqExpr{
-									pos: position{line: 511, col: 49, offset: 14565},
+									pos: position{line: 511, col: 49, offset: 14559},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 511, col: 49, offset: 14565},
+											pos:  position{line: 511, col: 49, offset: 14559},
 											name: "Annotation",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 511, col: 60, offset: 14576},
+											pos:  position{line: 511, col: 60, offset: 14570},
 											name: "_",
 										},
 									},
@@ -6995,25 +6916,25 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 512, col: 13, offset: 14592},
+							pos:        position{line: 512, col: 13, offset: 14586},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 512, col: 17, offset: 14596},
+							pos:  position{line: 512, col: 17, offset: 14590},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 512, col: 19, offset: 14598},
+							pos:   position{line: 512, col: 19, offset: 14592},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 512, col: 21, offset: 14600},
+								pos:  position{line: 512, col: 21, offset: 14594},
 								name: "Expression",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 512, col: 32, offset: 14611},
+							pos:  position{line: 512, col: 32, offset: 14605},
 							name: "_",
 						},
 					},
@@ -7022,15 +6943,15 @@ var g = &grammar{
 		},
 		{
 			name: "Expression",
-			pos:  position{line: 527, col: 1, offset: 14920},
+			pos:  position{line: 527, col: 1, offset: 14914},
 			expr: &choiceExpr{
-				pos: position{line: 528, col: 7, offset: 14941},
+				pos: position{line: 528, col: 7, offset: 14935},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 528, col: 7, offset: 14941},
+						pos: position{line: 528, col: 7, offset: 14935},
 						run: (*parser).callonExpression2,
 						expr: &seqExpr{
-							pos: position{line: 528, col: 7, offset: 14941},
+							pos: position{line: 528, col: 7, offset: 14935},
 							exprs: []interface{}{
 								&charClassMatcher{
 									pos:        position{line: 318, col: 10, offset: 8507},
@@ -7040,21 +6961,21 @@ var g = &grammar{
 									inverted:   false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 528, col: 14, offset: 14948},
+									pos:  position{line: 528, col: 14, offset: 14942},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 528, col: 16, offset: 14950},
+									pos:        position{line: 528, col: 16, offset: 14944},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 528, col: 20, offset: 14954},
+									pos:  position{line: 528, col: 20, offset: 14948},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 528, col: 22, offset: 14956},
+									pos:   position{line: 528, col: 22, offset: 14950},
 									label: "label",
 									expr: &choiceExpr{
 										pos: position{line: 149, col: 20, offset: 3633},
@@ -8562,39 +8483,39 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 528, col: 45, offset: 14979},
+									pos:  position{line: 528, col: 45, offset: 14973},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 528, col: 47, offset: 14981},
+									pos:        position{line: 528, col: 47, offset: 14975},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 528, col: 51, offset: 14985},
+									pos:  position{line: 528, col: 51, offset: 14979},
 									name: "_1",
 								},
 								&labeledExpr{
-									pos:   position{line: 528, col: 54, offset: 14988},
+									pos:   position{line: 528, col: 54, offset: 14982},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 528, col: 56, offset: 14990},
+										pos:  position{line: 528, col: 56, offset: 14984},
 										name: "Expression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 528, col: 67, offset: 15001},
+									pos:  position{line: 528, col: 67, offset: 14995},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 528, col: 69, offset: 15003},
+									pos:        position{line: 528, col: 69, offset: 14997},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 528, col: 73, offset: 15007},
+									pos:  position{line: 528, col: 73, offset: 15001},
 									name: "_",
 								},
 								&choiceExpr{
@@ -8615,14 +8536,14 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 528, col: 81, offset: 15015},
+									pos:  position{line: 528, col: 81, offset: 15009},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 528, col: 83, offset: 15017},
+									pos:   position{line: 528, col: 83, offset: 15011},
 									label: "body",
 									expr: &ruleRefExpr{
-										pos:  position{line: 528, col: 88, offset: 15022},
+										pos:  position{line: 528, col: 88, offset: 15016},
 										name: "Expression",
 									},
 								},
@@ -8630,10 +8551,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 531, col: 7, offset: 15134},
+						pos: position{line: 531, col: 7, offset: 15128},
 						run: (*parser).callonExpression312,
 						expr: &seqExpr{
-							pos: position{line: 531, col: 7, offset: 15134},
+							pos: position{line: 531, col: 7, offset: 15128},
 							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 246, col: 6, offset: 6332},
@@ -8642,19 +8563,19 @@ var g = &grammar{
 									want:       "\"if\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 531, col: 10, offset: 15137},
+									pos:  position{line: 531, col: 10, offset: 15131},
 									name: "_1",
 								},
 								&labeledExpr{
-									pos:   position{line: 531, col: 13, offset: 15140},
+									pos:   position{line: 531, col: 13, offset: 15134},
 									label: "cond",
 									expr: &ruleRefExpr{
-										pos:  position{line: 531, col: 18, offset: 15145},
+										pos:  position{line: 531, col: 18, offset: 15139},
 										name: "Expression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 531, col: 29, offset: 15156},
+									pos:  position{line: 531, col: 29, offset: 15150},
 									name: "_",
 								},
 								&litMatcher{
@@ -8664,19 +8585,19 @@ var g = &grammar{
 									want:       "\"then\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 531, col: 36, offset: 15163},
+									pos:  position{line: 531, col: 36, offset: 15157},
 									name: "_1",
 								},
 								&labeledExpr{
-									pos:   position{line: 531, col: 39, offset: 15166},
+									pos:   position{line: 531, col: 39, offset: 15160},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 531, col: 41, offset: 15168},
+										pos:  position{line: 531, col: 41, offset: 15162},
 										name: "Expression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 531, col: 52, offset: 15179},
+									pos:  position{line: 531, col: 52, offset: 15173},
 									name: "_",
 								},
 								&litMatcher{
@@ -8686,14 +8607,14 @@ var g = &grammar{
 									want:       "\"else\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 531, col: 59, offset: 15186},
+									pos:  position{line: 531, col: 59, offset: 15180},
 									name: "_1",
 								},
 								&labeledExpr{
-									pos:   position{line: 531, col: 62, offset: 15189},
+									pos:   position{line: 531, col: 62, offset: 15183},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 531, col: 64, offset: 15191},
+										pos:  position{line: 531, col: 64, offset: 15185},
 										name: "Expression",
 									},
 								},
@@ -8701,18 +8622,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 534, col: 7, offset: 15273},
+						pos: position{line: 534, col: 7, offset: 15267},
 						run: (*parser).callonExpression328,
 						expr: &seqExpr{
-							pos: position{line: 534, col: 7, offset: 15273},
+							pos: position{line: 534, col: 7, offset: 15267},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 534, col: 7, offset: 15273},
+									pos:   position{line: 534, col: 7, offset: 15267},
 									label: "bindings",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 534, col: 16, offset: 15282},
+										pos: position{line: 534, col: 16, offset: 15276},
 										expr: &ruleRefExpr{
-											pos:  position{line: 534, col: 16, offset: 15282},
+											pos:  position{line: 534, col: 16, offset: 15276},
 											name: "LetBinding",
 										},
 									},
@@ -8724,14 +8645,14 @@ var g = &grammar{
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 534, col: 31, offset: 15297},
+									pos:  position{line: 534, col: 31, offset: 15291},
 									name: "_1",
 								},
 								&labeledExpr{
-									pos:   position{line: 534, col: 34, offset: 15300},
+									pos:   position{line: 534, col: 34, offset: 15294},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 534, col: 36, offset: 15302},
+										pos:  position{line: 534, col: 36, offset: 15296},
 										name: "Expression",
 									},
 								},
@@ -8739,10 +8660,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 541, col: 7, offset: 15541},
+						pos: position{line: 541, col: 7, offset: 15535},
 						run: (*parser).callonExpression337,
 						expr: &seqExpr{
-							pos: position{line: 541, col: 7, offset: 15541},
+							pos: position{line: 541, col: 7, offset: 15535},
 							exprs: []interface{}{
 								&choiceExpr{
 									pos: position{line: 260, col: 10, offset: 6615},
@@ -8762,21 +8683,21 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 14, offset: 15548},
+									pos:  position{line: 541, col: 14, offset: 15542},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 541, col: 16, offset: 15550},
+									pos:        position{line: 541, col: 16, offset: 15544},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 20, offset: 15554},
+									pos:  position{line: 541, col: 20, offset: 15548},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 541, col: 22, offset: 15556},
+									pos:   position{line: 541, col: 22, offset: 15550},
 									label: "label",
 									expr: &choiceExpr{
 										pos: position{line: 149, col: 20, offset: 3633},
@@ -10284,39 +10205,39 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 45, offset: 15579},
+									pos:  position{line: 541, col: 45, offset: 15573},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 541, col: 47, offset: 15581},
+									pos:        position{line: 541, col: 47, offset: 15575},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 51, offset: 15585},
+									pos:  position{line: 541, col: 51, offset: 15579},
 									name: "_1",
 								},
 								&labeledExpr{
-									pos:   position{line: 541, col: 54, offset: 15588},
+									pos:   position{line: 541, col: 54, offset: 15582},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 541, col: 56, offset: 15590},
+										pos:  position{line: 541, col: 56, offset: 15584},
 										name: "Expression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 67, offset: 15601},
+									pos:  position{line: 541, col: 67, offset: 15595},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 541, col: 69, offset: 15603},
+									pos:        position{line: 541, col: 69, offset: 15597},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 73, offset: 15607},
+									pos:  position{line: 541, col: 73, offset: 15601},
 									name: "_",
 								},
 								&choiceExpr{
@@ -10337,14 +10258,14 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 81, offset: 15615},
+									pos:  position{line: 541, col: 81, offset: 15609},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 541, col: 83, offset: 15617},
+									pos:   position{line: 541, col: 83, offset: 15611},
 									label: "body",
 									expr: &ruleRefExpr{
-										pos:  position{line: 541, col: 88, offset: 15622},
+										pos:  position{line: 541, col: 88, offset: 15616},
 										name: "Expression",
 									},
 								},
@@ -10352,21 +10273,21 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 544, col: 7, offset: 15730},
+						pos: position{line: 544, col: 7, offset: 15724},
 						run: (*parser).callonExpression649,
 						expr: &seqExpr{
-							pos: position{line: 544, col: 7, offset: 15730},
+							pos: position{line: 544, col: 7, offset: 15724},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 544, col: 7, offset: 15730},
+									pos:   position{line: 544, col: 7, offset: 15724},
 									label: "o",
 									expr: &ruleRefExpr{
-										pos:  position{line: 544, col: 9, offset: 15732},
+										pos:  position{line: 544, col: 9, offset: 15726},
 										name: "OperatorExpression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 544, col: 28, offset: 15751},
+									pos:  position{line: 544, col: 28, offset: 15745},
 									name: "_",
 								},
 								&choiceExpr{
@@ -10387,14 +10308,14 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 544, col: 36, offset: 15759},
+									pos:  position{line: 544, col: 36, offset: 15753},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 544, col: 38, offset: 15761},
+									pos:   position{line: 544, col: 38, offset: 15755},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 544, col: 40, offset: 15763},
+										pos:  position{line: 544, col: 40, offset: 15757},
 										name: "Expression",
 									},
 								},
@@ -10402,14 +10323,14 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 545, col: 7, offset: 15825},
+						pos:  position{line: 545, col: 7, offset: 15819},
 						name: "WithExpression",
 					},
 					&actionExpr{
-						pos: position{line: 546, col: 7, offset: 15846},
+						pos: position{line: 546, col: 7, offset: 15840},
 						run: (*parser).callonExpression661,
 						expr: &seqExpr{
-							pos: position{line: 546, col: 7, offset: 15846},
+							pos: position{line: 546, col: 7, offset: 15840},
 							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 253, col: 9, offset: 6435},
@@ -10418,48 +10339,48 @@ var g = &grammar{
 									want:       "\"merge\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 13, offset: 15852},
+									pos:  position{line: 546, col: 13, offset: 15846},
 									name: "_1",
 								},
 								&labeledExpr{
-									pos:   position{line: 546, col: 16, offset: 15855},
+									pos:   position{line: 546, col: 16, offset: 15849},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 546, col: 18, offset: 15857},
+										pos:  position{line: 546, col: 18, offset: 15851},
 										name: "ImportExpression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 35, offset: 15874},
+									pos:  position{line: 546, col: 35, offset: 15868},
 									name: "_1",
 								},
 								&labeledExpr{
-									pos:   position{line: 546, col: 38, offset: 15877},
+									pos:   position{line: 546, col: 38, offset: 15871},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 546, col: 40, offset: 15879},
+										pos:  position{line: 546, col: 40, offset: 15873},
 										name: "ImportExpression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 57, offset: 15896},
+									pos:  position{line: 546, col: 57, offset: 15890},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 546, col: 59, offset: 15898},
+									pos:        position{line: 546, col: 59, offset: 15892},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 63, offset: 15902},
+									pos:  position{line: 546, col: 63, offset: 15896},
 									name: "_1",
 								},
 								&labeledExpr{
-									pos:   position{line: 546, col: 66, offset: 15905},
+									pos:   position{line: 546, col: 66, offset: 15899},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 546, col: 68, offset: 15907},
+										pos:  position{line: 546, col: 68, offset: 15901},
 										name: "ApplicationExpression",
 									},
 								},
@@ -10467,14 +10388,14 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 549, col: 7, offset: 16028},
+						pos:  position{line: 549, col: 7, offset: 16022},
 						name: "EmptyList",
 					},
 					&actionExpr{
-						pos: position{line: 550, col: 7, offset: 16044},
+						pos: position{line: 550, col: 7, offset: 16038},
 						run: (*parser).callonExpression676,
 						expr: &seqExpr{
-							pos: position{line: 550, col: 7, offset: 16044},
+							pos: position{line: 550, col: 7, offset: 16038},
 							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 258, col: 9, offset: 6576},
@@ -10483,36 +10404,36 @@ var g = &grammar{
 									want:       "\"toMap\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 550, col: 13, offset: 16050},
+									pos:  position{line: 550, col: 13, offset: 16044},
 									name: "_1",
 								},
 								&labeledExpr{
-									pos:   position{line: 550, col: 16, offset: 16053},
+									pos:   position{line: 550, col: 16, offset: 16047},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 550, col: 18, offset: 16055},
+										pos:  position{line: 550, col: 18, offset: 16049},
 										name: "ImportExpression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 550, col: 35, offset: 16072},
+									pos:  position{line: 550, col: 35, offset: 16066},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 550, col: 37, offset: 16074},
+									pos:        position{line: 550, col: 37, offset: 16068},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 550, col: 41, offset: 16078},
+									pos:  position{line: 550, col: 41, offset: 16072},
 									name: "_1",
 								},
 								&labeledExpr{
-									pos:   position{line: 550, col: 44, offset: 16081},
+									pos:   position{line: 550, col: 44, offset: 16075},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 550, col: 46, offset: 16083},
+										pos:  position{line: 550, col: 46, offset: 16077},
 										name: "ApplicationExpression",
 									},
 								},
@@ -10520,10 +10441,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 551, col: 7, offset: 16153},
+						pos: position{line: 551, col: 7, offset: 16147},
 						run: (*parser).callonExpression687,
 						expr: &seqExpr{
-							pos: position{line: 551, col: 7, offset: 16153},
+							pos: position{line: 551, col: 7, offset: 16147},
 							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 259, col: 10, offset: 6595},
@@ -10532,24 +10453,24 @@ var g = &grammar{
 									want:       "\"assert\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 551, col: 14, offset: 16160},
+									pos:  position{line: 551, col: 14, offset: 16154},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 551, col: 16, offset: 16162},
+									pos:        position{line: 551, col: 16, offset: 16156},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 551, col: 20, offset: 16166},
+									pos:  position{line: 551, col: 20, offset: 16160},
 									name: "_1",
 								},
 								&labeledExpr{
-									pos:   position{line: 551, col: 23, offset: 16169},
+									pos:   position{line: 551, col: 23, offset: 16163},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 551, col: 25, offset: 16171},
+										pos:  position{line: 551, col: 25, offset: 16165},
 										name: "Expression",
 									},
 								},
@@ -10557,7 +10478,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 552, col: 7, offset: 16233},
+						pos:  position{line: 552, col: 7, offset: 16227},
 						name: "AnnotatedExpression",
 					},
 				},
@@ -10565,28 +10486,28 @@ var g = &grammar{
 		},
 		{
 			name: "Annotation",
-			pos:  position{line: 554, col: 1, offset: 16254},
+			pos:  position{line: 554, col: 1, offset: 16248},
 			expr: &actionExpr{
-				pos: position{line: 554, col: 14, offset: 16269},
+				pos: position{line: 554, col: 14, offset: 16263},
 				run: (*parser).callonAnnotation1,
 				expr: &seqExpr{
-					pos: position{line: 554, col: 14, offset: 16269},
+					pos: position{line: 554, col: 14, offset: 16263},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 554, col: 14, offset: 16269},
+							pos:        position{line: 554, col: 14, offset: 16263},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 554, col: 18, offset: 16273},
+							pos:  position{line: 554, col: 18, offset: 16267},
 							name: "_1",
 						},
 						&labeledExpr{
-							pos:   position{line: 554, col: 21, offset: 16276},
+							pos:   position{line: 554, col: 21, offset: 16270},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 554, col: 23, offset: 16278},
+								pos:  position{line: 554, col: 23, offset: 16272},
 								name: "Expression",
 							},
 						},
@@ -10596,35 +10517,35 @@ var g = &grammar{
 		},
 		{
 			name: "AnnotatedExpression",
-			pos:  position{line: 556, col: 1, offset: 16308},
+			pos:  position{line: 556, col: 1, offset: 16302},
 			expr: &actionExpr{
-				pos: position{line: 557, col: 1, offset: 16332},
+				pos: position{line: 557, col: 1, offset: 16326},
 				run: (*parser).callonAnnotatedExpression1,
 				expr: &seqExpr{
-					pos: position{line: 557, col: 1, offset: 16332},
+					pos: position{line: 557, col: 1, offset: 16326},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 557, col: 1, offset: 16332},
+							pos:   position{line: 557, col: 1, offset: 16326},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 557, col: 3, offset: 16334},
+								pos:  position{line: 557, col: 3, offset: 16328},
 								name: "OperatorExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 557, col: 22, offset: 16353},
+							pos:   position{line: 557, col: 22, offset: 16347},
 							label: "a",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 557, col: 24, offset: 16355},
+								pos: position{line: 557, col: 24, offset: 16349},
 								expr: &seqExpr{
-									pos: position{line: 557, col: 25, offset: 16356},
+									pos: position{line: 557, col: 25, offset: 16350},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 557, col: 25, offset: 16356},
+											pos:  position{line: 557, col: 25, offset: 16350},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 557, col: 27, offset: 16358},
+											pos:  position{line: 557, col: 27, offset: 16352},
 											name: "Annotation",
 										},
 									},
@@ -10637,66 +10558,66 @@ var g = &grammar{
 		},
 		{
 			name: "EmptyList",
-			pos:  position{line: 562, col: 1, offset: 16483},
+			pos:  position{line: 562, col: 1, offset: 16477},
 			expr: &actionExpr{
-				pos: position{line: 562, col: 13, offset: 16497},
+				pos: position{line: 562, col: 13, offset: 16491},
 				run: (*parser).callonEmptyList1,
 				expr: &seqExpr{
-					pos: position{line: 562, col: 13, offset: 16497},
+					pos: position{line: 562, col: 13, offset: 16491},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 562, col: 13, offset: 16497},
+							pos:        position{line: 562, col: 13, offset: 16491},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 562, col: 17, offset: 16501},
+							pos:  position{line: 562, col: 17, offset: 16495},
 							name: "_",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 562, col: 19, offset: 16503},
+							pos: position{line: 562, col: 19, offset: 16497},
 							expr: &seqExpr{
-								pos: position{line: 562, col: 20, offset: 16504},
+								pos: position{line: 562, col: 20, offset: 16498},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 562, col: 20, offset: 16504},
+										pos:        position{line: 562, col: 20, offset: 16498},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 562, col: 24, offset: 16508},
+										pos:  position{line: 562, col: 24, offset: 16502},
 										name: "_",
 									},
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 562, col: 28, offset: 16512},
+							pos:        position{line: 562, col: 28, offset: 16506},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 562, col: 32, offset: 16516},
+							pos:  position{line: 562, col: 32, offset: 16510},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 562, col: 34, offset: 16518},
+							pos:        position{line: 562, col: 34, offset: 16512},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 562, col: 38, offset: 16522},
+							pos:  position{line: 562, col: 38, offset: 16516},
 							name: "_1",
 						},
 						&labeledExpr{
-							pos:   position{line: 562, col: 41, offset: 16525},
+							pos:   position{line: 562, col: 41, offset: 16519},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 562, col: 43, offset: 16527},
+								pos:  position{line: 562, col: 43, offset: 16521},
 								name: "ApplicationExpression",
 							},
 						},
@@ -10706,31 +10627,31 @@ var g = &grammar{
 		},
 		{
 			name: "WithExpression",
-			pos:  position{line: 566, col: 1, offset: 16595},
+			pos:  position{line: 566, col: 1, offset: 16589},
 			expr: &actionExpr{
-				pos: position{line: 567, col: 3, offset: 16616},
+				pos: position{line: 567, col: 3, offset: 16610},
 				run: (*parser).callonWithExpression1,
 				expr: &seqExpr{
-					pos: position{line: 567, col: 3, offset: 16616},
+					pos: position{line: 567, col: 3, offset: 16610},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 567, col: 3, offset: 16616},
+							pos:   position{line: 567, col: 3, offset: 16610},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 567, col: 9, offset: 16622},
+								pos:  position{line: 567, col: 9, offset: 16616},
 								name: "ImportExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 567, col: 26, offset: 16639},
+							pos:   position{line: 567, col: 26, offset: 16633},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 567, col: 31, offset: 16644},
+								pos: position{line: 567, col: 31, offset: 16638},
 								expr: &seqExpr{
-									pos: position{line: 567, col: 32, offset: 16645},
+									pos: position{line: 567, col: 32, offset: 16639},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 567, col: 32, offset: 16645},
+											pos:  position{line: 567, col: 32, offset: 16639},
 											name: "_1",
 										},
 										&litMatcher{
@@ -10740,11 +10661,11 @@ var g = &grammar{
 											want:       "\"with\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 567, col: 40, offset: 16653},
+											pos:  position{line: 567, col: 40, offset: 16647},
 											name: "_1",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 567, col: 43, offset: 16656},
+											pos:  position{line: 567, col: 43, offset: 16650},
 											name: "WithClause",
 										},
 									},
@@ -10757,30 +10678,30 @@ var g = &grammar{
 		},
 		{
 			name: "WithClause",
-			pos:  position{line: 580, col: 1, offset: 16994},
+			pos:  position{line: 580, col: 1, offset: 16988},
 			expr: &seqExpr{
-				pos: position{line: 580, col: 14, offset: 17009},
+				pos: position{line: 580, col: 14, offset: 17003},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 580, col: 14, offset: 17009},
+						pos:  position{line: 580, col: 14, offset: 17003},
 						name: "FieldPath",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 580, col: 24, offset: 17019},
+						pos:  position{line: 580, col: 24, offset: 17013},
 						name: "_",
 					},
 					&litMatcher{
-						pos:        position{line: 580, col: 26, offset: 17021},
+						pos:        position{line: 580, col: 26, offset: 17015},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 580, col: 30, offset: 17025},
+						pos:  position{line: 580, col: 30, offset: 17019},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 580, col: 32, offset: 17027},
+						pos:  position{line: 580, col: 32, offset: 17021},
 						name: "OperatorExpression",
 					},
 				},
@@ -10788,15 +10709,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldPath",
-			pos:  position{line: 582, col: 1, offset: 17047},
+			pos:  position{line: 582, col: 1, offset: 17041},
 			expr: &actionExpr{
-				pos: position{line: 582, col: 13, offset: 17061},
+				pos: position{line: 582, col: 13, offset: 17055},
 				run: (*parser).callonFieldPath1,
 				expr: &seqExpr{
-					pos: position{line: 582, col: 13, offset: 17061},
+					pos: position{line: 582, col: 13, offset: 17055},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 582, col: 13, offset: 17061},
+							pos:   position{line: 582, col: 13, offset: 17055},
 							label: "first",
 							expr: &choiceExpr{
 								pos: position{line: 154, col: 18, offset: 3799},
@@ -11172,25 +11093,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 582, col: 34, offset: 17082},
+							pos:   position{line: 582, col: 34, offset: 17076},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 582, col: 39, offset: 17087},
+								pos: position{line: 582, col: 39, offset: 17081},
 								expr: &seqExpr{
-									pos: position{line: 582, col: 40, offset: 17088},
+									pos: position{line: 582, col: 40, offset: 17082},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 582, col: 40, offset: 17088},
+											pos:  position{line: 582, col: 40, offset: 17082},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 582, col: 42, offset: 17090},
+											pos:        position{line: 582, col: 42, offset: 17084},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 582, col: 46, offset: 17094},
+											pos:  position{line: 582, col: 46, offset: 17088},
 											name: "_",
 										},
 										&choiceExpr{
@@ -11575,39 +11496,39 @@ var g = &grammar{
 		},
 		{
 			name: "OperatorExpression",
-			pos:  position{line: 592, col: 1, offset: 17334},
+			pos:  position{line: 592, col: 1, offset: 17328},
 			expr: &ruleRefExpr{
-				pos:  position{line: 592, col: 22, offset: 17357},
+				pos:  position{line: 592, col: 22, offset: 17351},
 				name: "EquivalentExpression",
 			},
 		},
 		{
 			name: "EquivalentExpression",
-			pos:  position{line: 594, col: 1, offset: 17379},
+			pos:  position{line: 594, col: 1, offset: 17373},
 			expr: &actionExpr{
-				pos: position{line: 594, col: 26, offset: 17406},
+				pos: position{line: 594, col: 26, offset: 17400},
 				run: (*parser).callonEquivalentExpression1,
 				expr: &seqExpr{
-					pos: position{line: 594, col: 26, offset: 17406},
+					pos: position{line: 594, col: 26, offset: 17400},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 594, col: 26, offset: 17406},
+							pos:   position{line: 594, col: 26, offset: 17400},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 594, col: 32, offset: 17412},
+								pos:  position{line: 594, col: 32, offset: 17406},
 								name: "ImportAltExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 594, col: 55, offset: 17435},
+							pos:   position{line: 594, col: 55, offset: 17429},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 594, col: 60, offset: 17440},
+								pos: position{line: 594, col: 60, offset: 17434},
 								expr: &seqExpr{
-									pos: position{line: 594, col: 61, offset: 17441},
+									pos: position{line: 594, col: 61, offset: 17435},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 594, col: 61, offset: 17441},
+											pos:  position{line: 594, col: 61, offset: 17435},
 											name: "_",
 										},
 										&choiceExpr{
@@ -11628,14 +11549,14 @@ var g = &grammar{
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 594, col: 74, offset: 17454},
+											pos:  position{line: 594, col: 74, offset: 17448},
 											name: "_",
 										},
 										&labeledExpr{
-											pos:   position{line: 594, col: 76, offset: 17456},
+											pos:   position{line: 594, col: 76, offset: 17450},
 											label: "e",
 											expr: &ruleRefExpr{
-												pos:  position{line: 594, col: 78, offset: 17458},
+												pos:  position{line: 594, col: 78, offset: 17452},
 												name: "ImportAltExpression",
 											},
 										},
@@ -11649,45 +11570,45 @@ var g = &grammar{
 		},
 		{
 			name: "ImportAltExpression",
-			pos:  position{line: 596, col: 1, offset: 17532},
+			pos:  position{line: 596, col: 1, offset: 17526},
 			expr: &actionExpr{
-				pos: position{line: 596, col: 26, offset: 17559},
+				pos: position{line: 596, col: 26, offset: 17553},
 				run: (*parser).callonImportAltExpression1,
 				expr: &seqExpr{
-					pos: position{line: 596, col: 26, offset: 17559},
+					pos: position{line: 596, col: 26, offset: 17553},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 596, col: 26, offset: 17559},
+							pos:   position{line: 596, col: 26, offset: 17553},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 596, col: 32, offset: 17565},
+								pos:  position{line: 596, col: 32, offset: 17559},
 								name: "OrExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 596, col: 55, offset: 17588},
+							pos:   position{line: 596, col: 55, offset: 17582},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 596, col: 60, offset: 17593},
+								pos: position{line: 596, col: 60, offset: 17587},
 								expr: &seqExpr{
-									pos: position{line: 596, col: 61, offset: 17594},
+									pos: position{line: 596, col: 61, offset: 17588},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 596, col: 61, offset: 17594},
+											pos:  position{line: 596, col: 61, offset: 17588},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 596, col: 63, offset: 17596},
+											pos:        position{line: 596, col: 63, offset: 17590},
 											val:        "?",
 											ignoreCase: false,
 											want:       "\"?\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 596, col: 67, offset: 17600},
+											pos:  position{line: 596, col: 67, offset: 17594},
 											name: "_1",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 596, col: 70, offset: 17603},
+											pos:  position{line: 596, col: 70, offset: 17597},
 											name: "OrExpression",
 										},
 									},
@@ -11700,45 +11621,45 @@ var g = &grammar{
 		},
 		{
 			name: "OrExpression",
-			pos:  position{line: 598, col: 1, offset: 17674},
+			pos:  position{line: 598, col: 1, offset: 17668},
 			expr: &actionExpr{
-				pos: position{line: 598, col: 26, offset: 17701},
+				pos: position{line: 598, col: 26, offset: 17695},
 				run: (*parser).callonOrExpression1,
 				expr: &seqExpr{
-					pos: position{line: 598, col: 26, offset: 17701},
+					pos: position{line: 598, col: 26, offset: 17695},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 598, col: 26, offset: 17701},
+							pos:   position{line: 598, col: 26, offset: 17695},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 598, col: 32, offset: 17707},
+								pos:  position{line: 598, col: 32, offset: 17701},
 								name: "PlusExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 598, col: 55, offset: 17730},
+							pos:   position{line: 598, col: 55, offset: 17724},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 598, col: 60, offset: 17735},
+								pos: position{line: 598, col: 60, offset: 17729},
 								expr: &seqExpr{
-									pos: position{line: 598, col: 61, offset: 17736},
+									pos: position{line: 598, col: 61, offset: 17730},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 598, col: 61, offset: 17736},
+											pos:  position{line: 598, col: 61, offset: 17730},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 598, col: 63, offset: 17738},
+											pos:        position{line: 598, col: 63, offset: 17732},
 											val:        "||",
 											ignoreCase: false,
 											want:       "\"||\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 598, col: 68, offset: 17743},
+											pos:  position{line: 598, col: 68, offset: 17737},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 598, col: 70, offset: 17745},
+											pos:  position{line: 598, col: 70, offset: 17739},
 											name: "PlusExpression",
 										},
 									},
@@ -11751,48 +11672,48 @@ var g = &grammar{
 		},
 		{
 			name: "PlusExpression",
-			pos:  position{line: 600, col: 1, offset: 17811},
+			pos:  position{line: 600, col: 1, offset: 17805},
 			expr: &actionExpr{
-				pos: position{line: 600, col: 26, offset: 17838},
+				pos: position{line: 600, col: 26, offset: 17832},
 				run: (*parser).callonPlusExpression1,
 				expr: &seqExpr{
-					pos: position{line: 600, col: 26, offset: 17838},
+					pos: position{line: 600, col: 26, offset: 17832},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 600, col: 26, offset: 17838},
+							pos:   position{line: 600, col: 26, offset: 17832},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 600, col: 32, offset: 17844},
+								pos:  position{line: 600, col: 32, offset: 17838},
 								name: "TextAppendExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 600, col: 55, offset: 17867},
+							pos:   position{line: 600, col: 55, offset: 17861},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 600, col: 60, offset: 17872},
+								pos: position{line: 600, col: 60, offset: 17866},
 								expr: &seqExpr{
-									pos: position{line: 600, col: 61, offset: 17873},
+									pos: position{line: 600, col: 61, offset: 17867},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 600, col: 61, offset: 17873},
+											pos:  position{line: 600, col: 61, offset: 17867},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 600, col: 63, offset: 17875},
+											pos:        position{line: 600, col: 63, offset: 17869},
 											val:        "+",
 											ignoreCase: false,
 											want:       "\"+\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 600, col: 67, offset: 17879},
+											pos:  position{line: 600, col: 67, offset: 17873},
 											name: "_1",
 										},
 										&labeledExpr{
-											pos:   position{line: 600, col: 70, offset: 17882},
+											pos:   position{line: 600, col: 70, offset: 17876},
 											label: "e",
 											expr: &ruleRefExpr{
-												pos:  position{line: 600, col: 72, offset: 17884},
+												pos:  position{line: 600, col: 72, offset: 17878},
 												name: "TextAppendExpression",
 											},
 										},
@@ -11806,48 +11727,48 @@ var g = &grammar{
 		},
 		{
 			name: "TextAppendExpression",
-			pos:  position{line: 602, col: 1, offset: 17958},
+			pos:  position{line: 602, col: 1, offset: 17952},
 			expr: &actionExpr{
-				pos: position{line: 602, col: 26, offset: 17985},
+				pos: position{line: 602, col: 26, offset: 17979},
 				run: (*parser).callonTextAppendExpression1,
 				expr: &seqExpr{
-					pos: position{line: 602, col: 26, offset: 17985},
+					pos: position{line: 602, col: 26, offset: 17979},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 602, col: 26, offset: 17985},
+							pos:   position{line: 602, col: 26, offset: 17979},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 602, col: 32, offset: 17991},
+								pos:  position{line: 602, col: 32, offset: 17985},
 								name: "ListAppendExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 602, col: 55, offset: 18014},
+							pos:   position{line: 602, col: 55, offset: 18008},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 602, col: 60, offset: 18019},
+								pos: position{line: 602, col: 60, offset: 18013},
 								expr: &seqExpr{
-									pos: position{line: 602, col: 61, offset: 18020},
+									pos: position{line: 602, col: 61, offset: 18014},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 602, col: 61, offset: 18020},
+											pos:  position{line: 602, col: 61, offset: 18014},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 602, col: 63, offset: 18022},
+											pos:        position{line: 602, col: 63, offset: 18016},
 											val:        "++",
 											ignoreCase: false,
 											want:       "\"++\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 602, col: 68, offset: 18027},
+											pos:  position{line: 602, col: 68, offset: 18021},
 											name: "_",
 										},
 										&labeledExpr{
-											pos:   position{line: 602, col: 70, offset: 18029},
+											pos:   position{line: 602, col: 70, offset: 18023},
 											label: "e",
 											expr: &ruleRefExpr{
-												pos:  position{line: 602, col: 72, offset: 18031},
+												pos:  position{line: 602, col: 72, offset: 18025},
 												name: "ListAppendExpression",
 											},
 										},
@@ -11861,48 +11782,48 @@ var g = &grammar{
 		},
 		{
 			name: "ListAppendExpression",
-			pos:  position{line: 604, col: 1, offset: 18111},
+			pos:  position{line: 604, col: 1, offset: 18105},
 			expr: &actionExpr{
-				pos: position{line: 604, col: 26, offset: 18138},
+				pos: position{line: 604, col: 26, offset: 18132},
 				run: (*parser).callonListAppendExpression1,
 				expr: &seqExpr{
-					pos: position{line: 604, col: 26, offset: 18138},
+					pos: position{line: 604, col: 26, offset: 18132},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 604, col: 26, offset: 18138},
+							pos:   position{line: 604, col: 26, offset: 18132},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 604, col: 32, offset: 18144},
+								pos:  position{line: 604, col: 32, offset: 18138},
 								name: "AndExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 604, col: 55, offset: 18167},
+							pos:   position{line: 604, col: 55, offset: 18161},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 604, col: 60, offset: 18172},
+								pos: position{line: 604, col: 60, offset: 18166},
 								expr: &seqExpr{
-									pos: position{line: 604, col: 61, offset: 18173},
+									pos: position{line: 604, col: 61, offset: 18167},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 604, col: 61, offset: 18173},
+											pos:  position{line: 604, col: 61, offset: 18167},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 604, col: 63, offset: 18175},
+											pos:        position{line: 604, col: 63, offset: 18169},
 											val:        "#",
 											ignoreCase: false,
 											want:       "\"#\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 604, col: 67, offset: 18179},
+											pos:  position{line: 604, col: 67, offset: 18173},
 											name: "_",
 										},
 										&labeledExpr{
-											pos:   position{line: 604, col: 69, offset: 18181},
+											pos:   position{line: 604, col: 69, offset: 18175},
 											label: "e",
 											expr: &ruleRefExpr{
-												pos:  position{line: 604, col: 71, offset: 18183},
+												pos:  position{line: 604, col: 71, offset: 18177},
 												name: "AndExpression",
 											},
 										},
@@ -11916,48 +11837,48 @@ var g = &grammar{
 		},
 		{
 			name: "AndExpression",
-			pos:  position{line: 606, col: 1, offset: 18256},
+			pos:  position{line: 606, col: 1, offset: 18250},
 			expr: &actionExpr{
-				pos: position{line: 606, col: 26, offset: 18283},
+				pos: position{line: 606, col: 26, offset: 18277},
 				run: (*parser).callonAndExpression1,
 				expr: &seqExpr{
-					pos: position{line: 606, col: 26, offset: 18283},
+					pos: position{line: 606, col: 26, offset: 18277},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 606, col: 26, offset: 18283},
+							pos:   position{line: 606, col: 26, offset: 18277},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 606, col: 32, offset: 18289},
+								pos:  position{line: 606, col: 32, offset: 18283},
 								name: "CombineExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 606, col: 55, offset: 18312},
+							pos:   position{line: 606, col: 55, offset: 18306},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 606, col: 60, offset: 18317},
+								pos: position{line: 606, col: 60, offset: 18311},
 								expr: &seqExpr{
-									pos: position{line: 606, col: 61, offset: 18318},
+									pos: position{line: 606, col: 61, offset: 18312},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 606, col: 61, offset: 18318},
+											pos:  position{line: 606, col: 61, offset: 18312},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 606, col: 63, offset: 18320},
+											pos:        position{line: 606, col: 63, offset: 18314},
 											val:        "&&",
 											ignoreCase: false,
 											want:       "\"&&\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 606, col: 68, offset: 18325},
+											pos:  position{line: 606, col: 68, offset: 18319},
 											name: "_",
 										},
 										&labeledExpr{
-											pos:   position{line: 606, col: 70, offset: 18327},
+											pos:   position{line: 606, col: 70, offset: 18321},
 											label: "e",
 											expr: &ruleRefExpr{
-												pos:  position{line: 606, col: 72, offset: 18329},
+												pos:  position{line: 606, col: 72, offset: 18323},
 												name: "CombineExpression",
 											},
 										},
@@ -11971,31 +11892,31 @@ var g = &grammar{
 		},
 		{
 			name: "CombineExpression",
-			pos:  position{line: 608, col: 1, offset: 18399},
+			pos:  position{line: 608, col: 1, offset: 18393},
 			expr: &actionExpr{
-				pos: position{line: 608, col: 26, offset: 18426},
+				pos: position{line: 608, col: 26, offset: 18420},
 				run: (*parser).callonCombineExpression1,
 				expr: &seqExpr{
-					pos: position{line: 608, col: 26, offset: 18426},
+					pos: position{line: 608, col: 26, offset: 18420},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 608, col: 26, offset: 18426},
+							pos:   position{line: 608, col: 26, offset: 18420},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 608, col: 32, offset: 18432},
+								pos:  position{line: 608, col: 32, offset: 18426},
 								name: "PreferExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 608, col: 55, offset: 18455},
+							pos:   position{line: 608, col: 55, offset: 18449},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 608, col: 60, offset: 18460},
+								pos: position{line: 608, col: 60, offset: 18454},
 								expr: &seqExpr{
-									pos: position{line: 608, col: 61, offset: 18461},
+									pos: position{line: 608, col: 61, offset: 18455},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 608, col: 61, offset: 18461},
+											pos:  position{line: 608, col: 61, offset: 18455},
 											name: "_",
 										},
 										&choiceExpr{
@@ -12016,14 +11937,14 @@ var g = &grammar{
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 608, col: 71, offset: 18471},
+											pos:  position{line: 608, col: 71, offset: 18465},
 											name: "_",
 										},
 										&labeledExpr{
-											pos:   position{line: 608, col: 73, offset: 18473},
+											pos:   position{line: 608, col: 73, offset: 18467},
 											label: "e",
 											expr: &ruleRefExpr{
-												pos:  position{line: 608, col: 75, offset: 18475},
+												pos:  position{line: 608, col: 75, offset: 18469},
 												name: "PreferExpression",
 											},
 										},
@@ -12037,31 +11958,31 @@ var g = &grammar{
 		},
 		{
 			name: "PreferExpression",
-			pos:  position{line: 610, col: 1, offset: 18552},
+			pos:  position{line: 610, col: 1, offset: 18546},
 			expr: &actionExpr{
-				pos: position{line: 610, col: 26, offset: 18579},
+				pos: position{line: 610, col: 26, offset: 18573},
 				run: (*parser).callonPreferExpression1,
 				expr: &seqExpr{
-					pos: position{line: 610, col: 26, offset: 18579},
+					pos: position{line: 610, col: 26, offset: 18573},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 610, col: 26, offset: 18579},
+							pos:   position{line: 610, col: 26, offset: 18573},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 610, col: 32, offset: 18585},
+								pos:  position{line: 610, col: 32, offset: 18579},
 								name: "CombineTypesExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 610, col: 55, offset: 18608},
+							pos:   position{line: 610, col: 55, offset: 18602},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 610, col: 60, offset: 18613},
+								pos: position{line: 610, col: 60, offset: 18607},
 								expr: &seqExpr{
-									pos: position{line: 610, col: 61, offset: 18614},
+									pos: position{line: 610, col: 61, offset: 18608},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 610, col: 61, offset: 18614},
+											pos:  position{line: 610, col: 61, offset: 18608},
 											name: "_",
 										},
 										&choiceExpr{
@@ -12082,14 +12003,14 @@ var g = &grammar{
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 610, col: 70, offset: 18623},
+											pos:  position{line: 610, col: 70, offset: 18617},
 											name: "_",
 										},
 										&labeledExpr{
-											pos:   position{line: 610, col: 72, offset: 18625},
+											pos:   position{line: 610, col: 72, offset: 18619},
 											label: "e",
 											expr: &ruleRefExpr{
-												pos:  position{line: 610, col: 74, offset: 18627},
+												pos:  position{line: 610, col: 74, offset: 18621},
 												name: "CombineTypesExpression",
 											},
 										},
@@ -12103,31 +12024,31 @@ var g = &grammar{
 		},
 		{
 			name: "CombineTypesExpression",
-			pos:  position{line: 612, col: 1, offset: 18721},
+			pos:  position{line: 612, col: 1, offset: 18715},
 			expr: &actionExpr{
-				pos: position{line: 612, col: 26, offset: 18748},
+				pos: position{line: 612, col: 26, offset: 18742},
 				run: (*parser).callonCombineTypesExpression1,
 				expr: &seqExpr{
-					pos: position{line: 612, col: 26, offset: 18748},
+					pos: position{line: 612, col: 26, offset: 18742},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 612, col: 26, offset: 18748},
+							pos:   position{line: 612, col: 26, offset: 18742},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 612, col: 32, offset: 18754},
+								pos:  position{line: 612, col: 32, offset: 18748},
 								name: "TimesExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 612, col: 55, offset: 18777},
+							pos:   position{line: 612, col: 55, offset: 18771},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 612, col: 60, offset: 18782},
+								pos: position{line: 612, col: 60, offset: 18776},
 								expr: &seqExpr{
-									pos: position{line: 612, col: 61, offset: 18783},
+									pos: position{line: 612, col: 61, offset: 18777},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 612, col: 61, offset: 18783},
+											pos:  position{line: 612, col: 61, offset: 18777},
 											name: "_",
 										},
 										&choiceExpr{
@@ -12148,14 +12069,14 @@ var g = &grammar{
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 612, col: 76, offset: 18798},
+											pos:  position{line: 612, col: 76, offset: 18792},
 											name: "_",
 										},
 										&labeledExpr{
-											pos:   position{line: 612, col: 78, offset: 18800},
+											pos:   position{line: 612, col: 78, offset: 18794},
 											label: "e",
 											expr: &ruleRefExpr{
-												pos:  position{line: 612, col: 80, offset: 18802},
+												pos:  position{line: 612, col: 80, offset: 18796},
 												name: "TimesExpression",
 											},
 										},
@@ -12169,48 +12090,48 @@ var g = &grammar{
 		},
 		{
 			name: "TimesExpression",
-			pos:  position{line: 614, col: 1, offset: 18882},
+			pos:  position{line: 614, col: 1, offset: 18876},
 			expr: &actionExpr{
-				pos: position{line: 614, col: 26, offset: 18909},
+				pos: position{line: 614, col: 26, offset: 18903},
 				run: (*parser).callonTimesExpression1,
 				expr: &seqExpr{
-					pos: position{line: 614, col: 26, offset: 18909},
+					pos: position{line: 614, col: 26, offset: 18903},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 614, col: 26, offset: 18909},
+							pos:   position{line: 614, col: 26, offset: 18903},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 614, col: 32, offset: 18915},
+								pos:  position{line: 614, col: 32, offset: 18909},
 								name: "EqualExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 614, col: 55, offset: 18938},
+							pos:   position{line: 614, col: 55, offset: 18932},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 614, col: 60, offset: 18943},
+								pos: position{line: 614, col: 60, offset: 18937},
 								expr: &seqExpr{
-									pos: position{line: 614, col: 61, offset: 18944},
+									pos: position{line: 614, col: 61, offset: 18938},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 614, col: 61, offset: 18944},
+											pos:  position{line: 614, col: 61, offset: 18938},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 614, col: 63, offset: 18946},
+											pos:        position{line: 614, col: 63, offset: 18940},
 											val:        "*",
 											ignoreCase: false,
 											want:       "\"*\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 614, col: 67, offset: 18950},
+											pos:  position{line: 614, col: 67, offset: 18944},
 											name: "_",
 										},
 										&labeledExpr{
-											pos:   position{line: 614, col: 69, offset: 18952},
+											pos:   position{line: 614, col: 69, offset: 18946},
 											label: "e",
 											expr: &ruleRefExpr{
-												pos:  position{line: 614, col: 71, offset: 18954},
+												pos:  position{line: 614, col: 71, offset: 18948},
 												name: "EqualExpression",
 											},
 										},
@@ -12224,48 +12145,48 @@ var g = &grammar{
 		},
 		{
 			name: "EqualExpression",
-			pos:  position{line: 616, col: 1, offset: 19024},
+			pos:  position{line: 616, col: 1, offset: 19018},
 			expr: &actionExpr{
-				pos: position{line: 616, col: 26, offset: 19051},
+				pos: position{line: 616, col: 26, offset: 19045},
 				run: (*parser).callonEqualExpression1,
 				expr: &seqExpr{
-					pos: position{line: 616, col: 26, offset: 19051},
+					pos: position{line: 616, col: 26, offset: 19045},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 616, col: 26, offset: 19051},
+							pos:   position{line: 616, col: 26, offset: 19045},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 616, col: 32, offset: 19057},
+								pos:  position{line: 616, col: 32, offset: 19051},
 								name: "NotEqualExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 616, col: 55, offset: 19080},
+							pos:   position{line: 616, col: 55, offset: 19074},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 616, col: 60, offset: 19085},
+								pos: position{line: 616, col: 60, offset: 19079},
 								expr: &seqExpr{
-									pos: position{line: 616, col: 61, offset: 19086},
+									pos: position{line: 616, col: 61, offset: 19080},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 616, col: 61, offset: 19086},
+											pos:  position{line: 616, col: 61, offset: 19080},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 616, col: 63, offset: 19088},
+											pos:        position{line: 616, col: 63, offset: 19082},
 											val:        "==",
 											ignoreCase: false,
 											want:       "\"==\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 616, col: 68, offset: 19093},
+											pos:  position{line: 616, col: 68, offset: 19087},
 											name: "_",
 										},
 										&labeledExpr{
-											pos:   position{line: 616, col: 70, offset: 19095},
+											pos:   position{line: 616, col: 70, offset: 19089},
 											label: "e",
 											expr: &ruleRefExpr{
-												pos:  position{line: 616, col: 72, offset: 19097},
+												pos:  position{line: 616, col: 72, offset: 19091},
 												name: "NotEqualExpression",
 											},
 										},
@@ -12279,48 +12200,48 @@ var g = &grammar{
 		},
 		{
 			name: "NotEqualExpression",
-			pos:  position{line: 618, col: 1, offset: 19167},
+			pos:  position{line: 618, col: 1, offset: 19161},
 			expr: &actionExpr{
-				pos: position{line: 618, col: 26, offset: 19194},
+				pos: position{line: 618, col: 26, offset: 19188},
 				run: (*parser).callonNotEqualExpression1,
 				expr: &seqExpr{
-					pos: position{line: 618, col: 26, offset: 19194},
+					pos: position{line: 618, col: 26, offset: 19188},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 618, col: 26, offset: 19194},
+							pos:   position{line: 618, col: 26, offset: 19188},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 618, col: 32, offset: 19200},
+								pos:  position{line: 618, col: 32, offset: 19194},
 								name: "ApplicationExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 618, col: 55, offset: 19223},
+							pos:   position{line: 618, col: 55, offset: 19217},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 618, col: 60, offset: 19228},
+								pos: position{line: 618, col: 60, offset: 19222},
 								expr: &seqExpr{
-									pos: position{line: 618, col: 61, offset: 19229},
+									pos: position{line: 618, col: 61, offset: 19223},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 618, col: 61, offset: 19229},
+											pos:  position{line: 618, col: 61, offset: 19223},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 618, col: 63, offset: 19231},
+											pos:        position{line: 618, col: 63, offset: 19225},
 											val:        "!=",
 											ignoreCase: false,
 											want:       "\"!=\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 618, col: 68, offset: 19236},
+											pos:  position{line: 618, col: 68, offset: 19230},
 											name: "_",
 										},
 										&labeledExpr{
-											pos:   position{line: 618, col: 70, offset: 19238},
+											pos:   position{line: 618, col: 70, offset: 19232},
 											label: "e",
 											expr: &ruleRefExpr{
-												pos:  position{line: 618, col: 72, offset: 19240},
+												pos:  position{line: 618, col: 72, offset: 19234},
 												name: "ApplicationExpression",
 											},
 										},
@@ -12334,35 +12255,35 @@ var g = &grammar{
 		},
 		{
 			name: "ApplicationExpression",
-			pos:  position{line: 621, col: 1, offset: 19314},
+			pos:  position{line: 621, col: 1, offset: 19308},
 			expr: &actionExpr{
-				pos: position{line: 621, col: 25, offset: 19340},
+				pos: position{line: 621, col: 25, offset: 19334},
 				run: (*parser).callonApplicationExpression1,
 				expr: &seqExpr{
-					pos: position{line: 621, col: 25, offset: 19340},
+					pos: position{line: 621, col: 25, offset: 19334},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 621, col: 25, offset: 19340},
+							pos:   position{line: 621, col: 25, offset: 19334},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 621, col: 27, offset: 19342},
+								pos:  position{line: 621, col: 27, offset: 19336},
 								name: "FirstApplicationExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 621, col: 55, offset: 19370},
+							pos:   position{line: 621, col: 55, offset: 19364},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 621, col: 60, offset: 19375},
+								pos: position{line: 621, col: 60, offset: 19369},
 								expr: &seqExpr{
-									pos: position{line: 621, col: 61, offset: 19376},
+									pos: position{line: 621, col: 61, offset: 19370},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 621, col: 61, offset: 19376},
+											pos:  position{line: 621, col: 61, offset: 19370},
 											name: "_1",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 621, col: 64, offset: 19379},
+											pos:  position{line: 621, col: 64, offset: 19373},
 											name: "ImportExpression",
 										},
 									},
@@ -12375,15 +12296,15 @@ var g = &grammar{
 		},
 		{
 			name: "FirstApplicationExpression",
-			pos:  position{line: 630, col: 1, offset: 19622},
+			pos:  position{line: 630, col: 1, offset: 19616},
 			expr: &choiceExpr{
-				pos: position{line: 631, col: 8, offset: 19660},
+				pos: position{line: 631, col: 8, offset: 19654},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 631, col: 8, offset: 19660},
+						pos: position{line: 631, col: 8, offset: 19654},
 						run: (*parser).callonFirstApplicationExpression2,
 						expr: &seqExpr{
-							pos: position{line: 631, col: 8, offset: 19660},
+							pos: position{line: 631, col: 8, offset: 19654},
 							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 253, col: 9, offset: 6435},
@@ -12392,26 +12313,26 @@ var g = &grammar{
 									want:       "\"merge\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 631, col: 14, offset: 19666},
+									pos:  position{line: 631, col: 14, offset: 19660},
 									name: "_1",
 								},
 								&labeledExpr{
-									pos:   position{line: 631, col: 17, offset: 19669},
+									pos:   position{line: 631, col: 17, offset: 19663},
 									label: "h",
 									expr: &ruleRefExpr{
-										pos:  position{line: 631, col: 19, offset: 19671},
+										pos:  position{line: 631, col: 19, offset: 19665},
 										name: "ImportExpression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 631, col: 36, offset: 19688},
+									pos:  position{line: 631, col: 36, offset: 19682},
 									name: "_1",
 								},
 								&labeledExpr{
-									pos:   position{line: 631, col: 39, offset: 19691},
+									pos:   position{line: 631, col: 39, offset: 19685},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 631, col: 41, offset: 19693},
+										pos:  position{line: 631, col: 41, offset: 19687},
 										name: "ImportExpression",
 									},
 								},
@@ -12419,10 +12340,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 634, col: 8, offset: 19796},
+						pos: position{line: 634, col: 8, offset: 19790},
 						run: (*parser).callonFirstApplicationExpression11,
 						expr: &seqExpr{
-							pos: position{line: 634, col: 8, offset: 19796},
+							pos: position{line: 634, col: 8, offset: 19790},
 							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 257, col: 8, offset: 6559},
@@ -12431,14 +12352,14 @@ var g = &grammar{
 									want:       "\"Some\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 634, col: 13, offset: 19801},
+									pos:  position{line: 634, col: 13, offset: 19795},
 									name: "_1",
 								},
 								&labeledExpr{
-									pos:   position{line: 634, col: 16, offset: 19804},
+									pos:   position{line: 634, col: 16, offset: 19798},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 634, col: 18, offset: 19806},
+										pos:  position{line: 634, col: 18, offset: 19800},
 										name: "ImportExpression",
 									},
 								},
@@ -12446,10 +12367,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 635, col: 8, offset: 19861},
+						pos: position{line: 635, col: 8, offset: 19855},
 						run: (*parser).callonFirstApplicationExpression17,
 						expr: &seqExpr{
-							pos: position{line: 635, col: 8, offset: 19861},
+							pos: position{line: 635, col: 8, offset: 19855},
 							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 258, col: 9, offset: 6576},
@@ -12458,14 +12379,14 @@ var g = &grammar{
 									want:       "\"toMap\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 635, col: 14, offset: 19867},
+									pos:  position{line: 635, col: 14, offset: 19861},
 									name: "_1",
 								},
 								&labeledExpr{
-									pos:   position{line: 635, col: 17, offset: 19870},
+									pos:   position{line: 635, col: 17, offset: 19864},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 635, col: 19, offset: 19872},
+										pos:  position{line: 635, col: 19, offset: 19866},
 										name: "ImportExpression",
 									},
 								},
@@ -12473,7 +12394,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 636, col: 8, offset: 19936},
+						pos:  position{line: 636, col: 8, offset: 19930},
 						name: "ImportExpression",
 					},
 				},
@@ -12481,16 +12402,16 @@ var g = &grammar{
 		},
 		{
 			name: "ImportExpression",
-			pos:  position{line: 638, col: 1, offset: 19954},
+			pos:  position{line: 638, col: 1, offset: 19948},
 			expr: &choiceExpr{
-				pos: position{line: 638, col: 20, offset: 19975},
+				pos: position{line: 638, col: 20, offset: 19969},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 638, col: 20, offset: 19975},
+						pos:  position{line: 638, col: 20, offset: 19969},
 						name: "Import",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 638, col: 29, offset: 19984},
+						pos:  position{line: 638, col: 29, offset: 19978},
 						name: "CompletionExpression",
 					},
 				},
@@ -12498,31 +12419,31 @@ var g = &grammar{
 		},
 		{
 			name: "CompletionExpression",
-			pos:  position{line: 640, col: 1, offset: 20006},
+			pos:  position{line: 640, col: 1, offset: 20000},
 			expr: &actionExpr{
-				pos: position{line: 640, col: 24, offset: 20031},
+				pos: position{line: 640, col: 24, offset: 20025},
 				run: (*parser).callonCompletionExpression1,
 				expr: &seqExpr{
-					pos: position{line: 640, col: 24, offset: 20031},
+					pos: position{line: 640, col: 24, offset: 20025},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 640, col: 24, offset: 20031},
+							pos:   position{line: 640, col: 24, offset: 20025},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 640, col: 26, offset: 20033},
+								pos:  position{line: 640, col: 26, offset: 20027},
 								name: "SelectorExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 640, col: 45, offset: 20052},
+							pos:   position{line: 640, col: 45, offset: 20046},
 							label: "b",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 640, col: 47, offset: 20054},
+								pos: position{line: 640, col: 47, offset: 20048},
 								expr: &seqExpr{
-									pos: position{line: 640, col: 48, offset: 20055},
+									pos: position{line: 640, col: 48, offset: 20049},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 640, col: 48, offset: 20055},
+											pos:  position{line: 640, col: 48, offset: 20049},
 											name: "_",
 										},
 										&litMatcher{
@@ -12532,11 +12453,11 @@ var g = &grammar{
 											want:       "\"::\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 640, col: 59, offset: 20066},
+											pos:  position{line: 640, col: 59, offset: 20060},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 640, col: 61, offset: 20068},
+											pos:  position{line: 640, col: 61, offset: 20062},
 											name: "SelectorExpression",
 										},
 									},
@@ -12549,45 +12470,45 @@ var g = &grammar{
 		},
 		{
 			name: "SelectorExpression",
-			pos:  position{line: 647, col: 1, offset: 20219},
+			pos:  position{line: 647, col: 1, offset: 20213},
 			expr: &actionExpr{
-				pos: position{line: 647, col: 22, offset: 20242},
+				pos: position{line: 647, col: 22, offset: 20236},
 				run: (*parser).callonSelectorExpression1,
 				expr: &seqExpr{
-					pos: position{line: 647, col: 22, offset: 20242},
+					pos: position{line: 647, col: 22, offset: 20236},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 647, col: 22, offset: 20242},
+							pos:   position{line: 647, col: 22, offset: 20236},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 647, col: 24, offset: 20244},
+								pos:  position{line: 647, col: 24, offset: 20238},
 								name: "PrimitiveExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 647, col: 44, offset: 20264},
+							pos:   position{line: 647, col: 44, offset: 20258},
 							label: "ls",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 647, col: 47, offset: 20267},
+								pos: position{line: 647, col: 47, offset: 20261},
 								expr: &seqExpr{
-									pos: position{line: 647, col: 48, offset: 20268},
+									pos: position{line: 647, col: 48, offset: 20262},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 647, col: 48, offset: 20268},
+											pos:  position{line: 647, col: 48, offset: 20262},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 647, col: 50, offset: 20270},
+											pos:        position{line: 647, col: 50, offset: 20264},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 647, col: 54, offset: 20274},
+											pos:  position{line: 647, col: 54, offset: 20268},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 647, col: 56, offset: 20276},
+											pos:  position{line: 647, col: 56, offset: 20270},
 											name: "Selector",
 										},
 									},
@@ -12600,9 +12521,9 @@ var g = &grammar{
 		},
 		{
 			name: "Selector",
-			pos:  position{line: 666, col: 1, offset: 20829},
+			pos:  position{line: 666, col: 1, offset: 20823},
 			expr: &choiceExpr{
-				pos: position{line: 666, col: 12, offset: 20842},
+				pos: position{line: 666, col: 12, offset: 20836},
 				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 146, col: 9, offset: 3515},
@@ -12962,11 +12883,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 666, col: 23, offset: 20853},
+						pos:  position{line: 666, col: 23, offset: 20847},
 						name: "Labels",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 666, col: 32, offset: 20862},
+						pos:  position{line: 666, col: 32, offset: 20856},
 						name: "TypeSelector",
 					},
 				},
@@ -12974,30 +12895,30 @@ var g = &grammar{
 		},
 		{
 			name: "Labels",
-			pos:  position{line: 668, col: 1, offset: 20876},
+			pos:  position{line: 668, col: 1, offset: 20870},
 			expr: &actionExpr{
-				pos: position{line: 668, col: 10, offset: 20887},
+				pos: position{line: 668, col: 10, offset: 20881},
 				run: (*parser).callonLabels1,
 				expr: &seqExpr{
-					pos: position{line: 668, col: 10, offset: 20887},
+					pos: position{line: 668, col: 10, offset: 20881},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 668, col: 10, offset: 20887},
+							pos:        position{line: 668, col: 10, offset: 20881},
 							val:        "{",
 							ignoreCase: false,
 							want:       "\"{\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 668, col: 14, offset: 20891},
+							pos:  position{line: 668, col: 14, offset: 20885},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 668, col: 16, offset: 20893},
+							pos:   position{line: 668, col: 16, offset: 20887},
 							label: "optclauses",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 668, col: 27, offset: 20904},
+								pos: position{line: 668, col: 27, offset: 20898},
 								expr: &seqExpr{
-									pos: position{line: 668, col: 29, offset: 20906},
+									pos: position{line: 668, col: 29, offset: 20900},
 									exprs: []interface{}{
 										&choiceExpr{
 											pos: position{line: 154, col: 18, offset: 3799},
@@ -13372,22 +13293,22 @@ var g = &grammar{
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 668, col: 44, offset: 20921},
+											pos:  position{line: 668, col: 44, offset: 20915},
 											name: "_",
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 668, col: 46, offset: 20923},
+											pos: position{line: 668, col: 46, offset: 20917},
 											expr: &seqExpr{
-												pos: position{line: 668, col: 47, offset: 20924},
+												pos: position{line: 668, col: 47, offset: 20918},
 												exprs: []interface{}{
 													&litMatcher{
-														pos:        position{line: 668, col: 47, offset: 20924},
+														pos:        position{line: 668, col: 47, offset: 20918},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 668, col: 51, offset: 20928},
+														pos:  position{line: 668, col: 51, offset: 20922},
 														name: "_",
 													},
 													&choiceExpr{
@@ -13763,7 +13684,7 @@ var g = &grammar{
 														},
 													},
 													&ruleRefExpr{
-														pos:  position{line: 668, col: 68, offset: 20945},
+														pos:  position{line: 668, col: 68, offset: 20939},
 														name: "_",
 													},
 												},
@@ -13774,7 +13695,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 668, col: 76, offset: 20953},
+							pos:        position{line: 668, col: 76, offset: 20947},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -13785,37 +13706,37 @@ var g = &grammar{
 		},
 		{
 			name: "TypeSelector",
-			pos:  position{line: 678, col: 1, offset: 21249},
+			pos:  position{line: 678, col: 1, offset: 21243},
 			expr: &actionExpr{
-				pos: position{line: 678, col: 16, offset: 21266},
+				pos: position{line: 678, col: 16, offset: 21260},
 				run: (*parser).callonTypeSelector1,
 				expr: &seqExpr{
-					pos: position{line: 678, col: 16, offset: 21266},
+					pos: position{line: 678, col: 16, offset: 21260},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 678, col: 16, offset: 21266},
+							pos:        position{line: 678, col: 16, offset: 21260},
 							val:        "(",
 							ignoreCase: false,
 							want:       "\"(\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 678, col: 20, offset: 21270},
+							pos:  position{line: 678, col: 20, offset: 21264},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 678, col: 22, offset: 21272},
+							pos:   position{line: 678, col: 22, offset: 21266},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 678, col: 24, offset: 21274},
+								pos:  position{line: 678, col: 24, offset: 21268},
 								name: "Expression",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 678, col: 35, offset: 21285},
+							pos:  position{line: 678, col: 35, offset: 21279},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 678, col: 37, offset: 21287},
+							pos:        position{line: 678, col: 37, offset: 21281},
 							val:        ")",
 							ignoreCase: false,
 							want:       "\")\"",
@@ -13826,9 +13747,9 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveExpression",
-			pos:  position{line: 680, col: 1, offset: 21310},
+			pos:  position{line: 680, col: 1, offset: 21304},
 			expr: &choiceExpr{
-				pos: position{line: 681, col: 7, offset: 21340},
+				pos: position{line: 681, col: 7, offset: 21334},
 				alternatives: []interface{}{
 					&labeledExpr{
 						pos:   position{line: 332, col: 17, offset: 8830},
@@ -14330,57 +14251,57 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 684, col: 7, offset: 21402},
+						pos:  position{line: 684, col: 7, offset: 21396},
 						name: "TextLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 685, col: 7, offset: 21420},
+						pos: position{line: 685, col: 7, offset: 21414},
 						run: (*parser).callonPrimitiveExpression101,
 						expr: &seqExpr{
-							pos: position{line: 685, col: 7, offset: 21420},
+							pos: position{line: 685, col: 7, offset: 21414},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 685, col: 7, offset: 21420},
+									pos:        position{line: 685, col: 7, offset: 21414},
 									val:        "{",
 									ignoreCase: false,
 									want:       "\"{\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 685, col: 11, offset: 21424},
+									pos:  position{line: 685, col: 11, offset: 21418},
 									name: "_",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 685, col: 13, offset: 21426},
+									pos: position{line: 685, col: 13, offset: 21420},
 									expr: &seqExpr{
-										pos: position{line: 685, col: 14, offset: 21427},
+										pos: position{line: 685, col: 14, offset: 21421},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 685, col: 14, offset: 21427},
+												pos:        position{line: 685, col: 14, offset: 21421},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 685, col: 18, offset: 21431},
+												pos:  position{line: 685, col: 18, offset: 21425},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 685, col: 22, offset: 21435},
+									pos:   position{line: 685, col: 22, offset: 21429},
 									label: "r",
 									expr: &ruleRefExpr{
-										pos:  position{line: 685, col: 24, offset: 21437},
+										pos:  position{line: 685, col: 24, offset: 21431},
 										name: "RecordTypeOrLiteral",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 685, col: 44, offset: 21457},
+									pos:  position{line: 685, col: 44, offset: 21451},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 685, col: 46, offset: 21459},
+									pos:        position{line: 685, col: 46, offset: 21453},
 									val:        "}",
 									ignoreCase: false,
 									want:       "\"}\"",
@@ -14389,53 +14310,53 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 686, col: 7, offset: 21487},
+						pos: position{line: 686, col: 7, offset: 21481},
 						run: (*parser).callonPrimitiveExpression113,
 						expr: &seqExpr{
-							pos: position{line: 686, col: 7, offset: 21487},
+							pos: position{line: 686, col: 7, offset: 21481},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 686, col: 7, offset: 21487},
+									pos:        position{line: 686, col: 7, offset: 21481},
 									val:        "<",
 									ignoreCase: false,
 									want:       "\"<\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 686, col: 11, offset: 21491},
+									pos:  position{line: 686, col: 11, offset: 21485},
 									name: "_",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 686, col: 13, offset: 21493},
+									pos: position{line: 686, col: 13, offset: 21487},
 									expr: &seqExpr{
-										pos: position{line: 686, col: 14, offset: 21494},
+										pos: position{line: 686, col: 14, offset: 21488},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 686, col: 14, offset: 21494},
+												pos:        position{line: 686, col: 14, offset: 21488},
 												val:        "|",
 												ignoreCase: false,
 												want:       "\"|\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 686, col: 18, offset: 21498},
+												pos:  position{line: 686, col: 18, offset: 21492},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 686, col: 22, offset: 21502},
+									pos:   position{line: 686, col: 22, offset: 21496},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 686, col: 24, offset: 21504},
+										pos:  position{line: 686, col: 24, offset: 21498},
 										name: "UnionType",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 686, col: 34, offset: 21514},
+									pos:  position{line: 686, col: 34, offset: 21508},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 686, col: 36, offset: 21516},
+									pos:        position{line: 686, col: 36, offset: 21510},
 									val:        ">",
 									ignoreCase: false,
 									want:       "\">\"",
@@ -14444,61 +14365,61 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 687, col: 7, offset: 21544},
+						pos:  position{line: 687, col: 7, offset: 21538},
 						name: "NonEmptyListLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 688, col: 7, offset: 21570},
+						pos:  position{line: 688, col: 7, offset: 21564},
 						name: "Identifier",
 					},
 					&actionExpr{
-						pos: position{line: 689, col: 7, offset: 21587},
+						pos: position{line: 689, col: 7, offset: 21581},
 						run: (*parser).callonPrimitiveExpression127,
 						expr: &seqExpr{
-							pos: position{line: 689, col: 7, offset: 21587},
+							pos: position{line: 689, col: 7, offset: 21581},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 689, col: 7, offset: 21587},
+									pos:        position{line: 689, col: 7, offset: 21581},
 									val:        "(",
 									ignoreCase: false,
 									want:       "\"(\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 689, col: 11, offset: 21591},
+									pos:  position{line: 689, col: 11, offset: 21585},
 									name: "_",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 689, col: 13, offset: 21593},
+									pos: position{line: 689, col: 13, offset: 21587},
 									expr: &seqExpr{
-										pos: position{line: 689, col: 14, offset: 21594},
+										pos: position{line: 689, col: 14, offset: 21588},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 689, col: 14, offset: 21594},
+												pos:        position{line: 689, col: 14, offset: 21588},
 												val:        "|",
 												ignoreCase: false,
 												want:       "\"|\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 689, col: 18, offset: 21598},
+												pos:  position{line: 689, col: 18, offset: 21592},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 689, col: 22, offset: 21602},
+									pos:   position{line: 689, col: 22, offset: 21596},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 689, col: 24, offset: 21604},
+										pos:  position{line: 689, col: 24, offset: 21598},
 										name: "Expression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 689, col: 35, offset: 21615},
+									pos:  position{line: 689, col: 35, offset: 21609},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 689, col: 37, offset: 21617},
+									pos:        position{line: 689, col: 37, offset: 21611},
 									val:        ")",
 									ignoreCase: false,
 									want:       "\")\"",
@@ -14511,33 +14432,33 @@ var g = &grammar{
 		},
 		{
 			name: "RecordTypeOrLiteral",
-			pos:  position{line: 691, col: 1, offset: 21640},
+			pos:  position{line: 691, col: 1, offset: 21634},
 			expr: &choiceExpr{
-				pos: position{line: 692, col: 7, offset: 21670},
+				pos: position{line: 692, col: 7, offset: 21664},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 692, col: 7, offset: 21670},
+						pos: position{line: 692, col: 7, offset: 21664},
 						run: (*parser).callonRecordTypeOrLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 692, col: 7, offset: 21670},
+							pos:        position{line: 692, col: 7, offset: 21664},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 693, col: 7, offset: 21708},
+						pos:  position{line: 693, col: 7, offset: 21702},
 						name: "NonEmptyRecordType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 694, col: 7, offset: 21733},
+						pos:  position{line: 694, col: 7, offset: 21727},
 						name: "NonEmptyRecordLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 695, col: 7, offset: 21761},
+						pos: position{line: 695, col: 7, offset: 21755},
 						run: (*parser).callonRecordTypeOrLiteral6,
 						expr: &litMatcher{
-							pos:        position{line: 695, col: 7, offset: 21761},
+							pos:        position{line: 695, col: 7, offset: 21755},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -14548,32 +14469,32 @@ var g = &grammar{
 		},
 		{
 			name: "MoreRecordType",
-			pos:  position{line: 697, col: 1, offset: 21794},
+			pos:  position{line: 697, col: 1, offset: 21788},
 			expr: &actionExpr{
-				pos: position{line: 697, col: 18, offset: 21813},
+				pos: position{line: 697, col: 18, offset: 21807},
 				run: (*parser).callonMoreRecordType1,
 				expr: &seqExpr{
-					pos: position{line: 697, col: 18, offset: 21813},
+					pos: position{line: 697, col: 18, offset: 21807},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 697, col: 18, offset: 21813},
+							pos:  position{line: 697, col: 18, offset: 21807},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 697, col: 20, offset: 21815},
+							pos:        position{line: 697, col: 20, offset: 21809},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 697, col: 24, offset: 21819},
+							pos:  position{line: 697, col: 24, offset: 21813},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 697, col: 26, offset: 21821},
+							pos:   position{line: 697, col: 26, offset: 21815},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 697, col: 28, offset: 21823},
+								pos:  position{line: 697, col: 28, offset: 21817},
 								name: "RecordTypeEntry",
 							},
 						},
@@ -14583,28 +14504,28 @@ var g = &grammar{
 		},
 		{
 			name: "NonEmptyRecordType",
-			pos:  position{line: 698, col: 1, offset: 21855},
+			pos:  position{line: 698, col: 1, offset: 21849},
 			expr: &actionExpr{
-				pos: position{line: 699, col: 7, offset: 21884},
+				pos: position{line: 699, col: 7, offset: 21878},
 				run: (*parser).callonNonEmptyRecordType1,
 				expr: &seqExpr{
-					pos: position{line: 699, col: 7, offset: 21884},
+					pos: position{line: 699, col: 7, offset: 21878},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 699, col: 7, offset: 21884},
+							pos:   position{line: 699, col: 7, offset: 21878},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 699, col: 13, offset: 21890},
+								pos:  position{line: 699, col: 13, offset: 21884},
 								name: "RecordTypeEntry",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 699, col: 29, offset: 21906},
+							pos:   position{line: 699, col: 29, offset: 21900},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 699, col: 34, offset: 21911},
+								pos: position{line: 699, col: 34, offset: 21905},
 								expr: &ruleRefExpr{
-									pos:  position{line: 699, col: 34, offset: 21911},
+									pos:  position{line: 699, col: 34, offset: 21905},
 									name: "MoreRecordType",
 								},
 							},
@@ -14615,15 +14536,15 @@ var g = &grammar{
 		},
 		{
 			name: "RecordTypeEntry",
-			pos:  position{line: 713, col: 1, offset: 22351},
+			pos:  position{line: 713, col: 1, offset: 22345},
 			expr: &actionExpr{
-				pos: position{line: 713, col: 19, offset: 22371},
+				pos: position{line: 713, col: 19, offset: 22365},
 				run: (*parser).callonRecordTypeEntry1,
 				expr: &seqExpr{
-					pos: position{line: 713, col: 19, offset: 22371},
+					pos: position{line: 713, col: 19, offset: 22365},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 713, col: 19, offset: 22371},
+							pos:   position{line: 713, col: 19, offset: 22365},
 							label: "name",
 							expr: &choiceExpr{
 								pos: position{line: 154, col: 18, offset: 3799},
@@ -14999,24 +14920,24 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 713, col: 39, offset: 22391},
+							pos:  position{line: 713, col: 39, offset: 22385},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 713, col: 41, offset: 22393},
+							pos:        position{line: 713, col: 41, offset: 22387},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 713, col: 45, offset: 22397},
+							pos:  position{line: 713, col: 45, offset: 22391},
 							name: "_1",
 						},
 						&labeledExpr{
-							pos:   position{line: 713, col: 48, offset: 22400},
+							pos:   position{line: 713, col: 48, offset: 22394},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 713, col: 53, offset: 22405},
+								pos:  position{line: 713, col: 53, offset: 22399},
 								name: "Expression",
 							},
 						},
@@ -15026,32 +14947,32 @@ var g = &grammar{
 		},
 		{
 			name: "MoreRecordLiteral",
-			pos:  position{line: 717, col: 1, offset: 22476},
+			pos:  position{line: 717, col: 1, offset: 22470},
 			expr: &actionExpr{
-				pos: position{line: 717, col: 21, offset: 22498},
+				pos: position{line: 717, col: 21, offset: 22492},
 				run: (*parser).callonMoreRecordLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 717, col: 21, offset: 22498},
+					pos: position{line: 717, col: 21, offset: 22492},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 717, col: 21, offset: 22498},
+							pos:  position{line: 717, col: 21, offset: 22492},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 717, col: 23, offset: 22500},
+							pos:        position{line: 717, col: 23, offset: 22494},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 717, col: 27, offset: 22504},
+							pos:  position{line: 717, col: 27, offset: 22498},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 717, col: 29, offset: 22506},
+							pos:   position{line: 717, col: 29, offset: 22500},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 717, col: 31, offset: 22508},
+								pos:  position{line: 717, col: 31, offset: 22502},
 								name: "RecordLiteralEntry",
 							},
 						},
@@ -15061,28 +14982,28 @@ var g = &grammar{
 		},
 		{
 			name: "NonEmptyRecordLiteral",
-			pos:  position{line: 718, col: 1, offset: 22543},
+			pos:  position{line: 718, col: 1, offset: 22537},
 			expr: &actionExpr{
-				pos: position{line: 719, col: 7, offset: 22575},
+				pos: position{line: 719, col: 7, offset: 22569},
 				run: (*parser).callonNonEmptyRecordLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 719, col: 7, offset: 22575},
+					pos: position{line: 719, col: 7, offset: 22569},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 719, col: 7, offset: 22575},
+							pos:   position{line: 719, col: 7, offset: 22569},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 719, col: 13, offset: 22581},
+								pos:  position{line: 719, col: 13, offset: 22575},
 								name: "RecordLiteralEntry",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 719, col: 32, offset: 22600},
+							pos:   position{line: 719, col: 32, offset: 22594},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 719, col: 37, offset: 22605},
+								pos: position{line: 719, col: 37, offset: 22599},
 								expr: &ruleRefExpr{
-									pos:  position{line: 719, col: 37, offset: 22605},
+									pos:  position{line: 719, col: 37, offset: 22599},
 									name: "MoreRecordLiteral",
 								},
 							},
@@ -15093,15 +15014,15 @@ var g = &grammar{
 		},
 		{
 			name: "RecordLiteralEntry",
-			pos:  position{line: 738, col: 1, offset: 23182},
+			pos:  position{line: 738, col: 1, offset: 23176},
 			expr: &actionExpr{
-				pos: position{line: 738, col: 22, offset: 23205},
+				pos: position{line: 738, col: 22, offset: 23199},
 				run: (*parser).callonRecordLiteralEntry1,
 				expr: &seqExpr{
-					pos: position{line: 738, col: 22, offset: 23205},
+					pos: position{line: 738, col: 22, offset: 23199},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 738, col: 22, offset: 23205},
+							pos:   position{line: 738, col: 22, offset: 23199},
 							label: "name",
 							expr: &choiceExpr{
 								pos: position{line: 154, col: 18, offset: 3799},
@@ -15477,17 +15398,17 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 738, col: 42, offset: 23225},
+							pos:   position{line: 738, col: 42, offset: 23219},
 							label: "val",
 							expr: &choiceExpr{
-								pos: position{line: 738, col: 47, offset: 23230},
+								pos: position{line: 738, col: 47, offset: 23224},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 738, col: 47, offset: 23230},
+										pos:  position{line: 738, col: 47, offset: 23224},
 										name: "RecordLiteralNormalEntry",
 									},
 									&litMatcher{
-										pos:        position{line: 755, col: 28, offset: 23819},
+										pos:        position{line: 755, col: 28, offset: 23813},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -15501,33 +15422,33 @@ var g = &grammar{
 		},
 		{
 			name: "RecordLiteralNormalEntry",
-			pos:  position{line: 746, col: 1, offset: 23477},
+			pos:  position{line: 746, col: 1, offset: 23471},
 			expr: &actionExpr{
-				pos: position{line: 746, col: 28, offset: 23506},
+				pos: position{line: 746, col: 28, offset: 23500},
 				run: (*parser).callonRecordLiteralNormalEntry1,
 				expr: &seqExpr{
-					pos: position{line: 746, col: 28, offset: 23506},
+					pos: position{line: 746, col: 28, offset: 23500},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 746, col: 28, offset: 23506},
+							pos:   position{line: 746, col: 28, offset: 23500},
 							label: "children",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 746, col: 37, offset: 23515},
+								pos: position{line: 746, col: 37, offset: 23509},
 								expr: &seqExpr{
-									pos: position{line: 746, col: 38, offset: 23516},
+									pos: position{line: 746, col: 38, offset: 23510},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 746, col: 38, offset: 23516},
+											pos:  position{line: 746, col: 38, offset: 23510},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 746, col: 40, offset: 23518},
+											pos:        position{line: 746, col: 40, offset: 23512},
 											val:        ".",
 											ignoreCase: false,
 											want:       "\".\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 746, col: 44, offset: 23522},
+											pos:  position{line: 746, col: 44, offset: 23516},
 											name: "_",
 										},
 										&choiceExpr{
@@ -15907,24 +15828,24 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 746, col: 63, offset: 23541},
+							pos:  position{line: 746, col: 63, offset: 23535},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 746, col: 65, offset: 23543},
+							pos:        position{line: 746, col: 65, offset: 23537},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 746, col: 69, offset: 23547},
+							pos:  position{line: 746, col: 69, offset: 23541},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 746, col: 71, offset: 23549},
+							pos:   position{line: 746, col: 71, offset: 23543},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 746, col: 76, offset: 23554},
+								pos:  position{line: 746, col: 76, offset: 23548},
 								name: "Expression",
 							},
 						},
@@ -15934,19 +15855,19 @@ var g = &grammar{
 		},
 		{
 			name: "UnionType",
-			pos:  position{line: 757, col: 1, offset: 23823},
+			pos:  position{line: 757, col: 1, offset: 23817},
 			expr: &choiceExpr{
-				pos: position{line: 757, col: 13, offset: 23837},
+				pos: position{line: 757, col: 13, offset: 23831},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 757, col: 13, offset: 23837},
+						pos:  position{line: 757, col: 13, offset: 23831},
 						name: "NonEmptyUnionType",
 					},
 					&actionExpr{
-						pos: position{line: 759, col: 18, offset: 23892},
+						pos: position{line: 759, col: 18, offset: 23886},
 						run: (*parser).callonUnionType3,
 						expr: &litMatcher{
-							pos:        position{line: 759, col: 18, offset: 23892},
+							pos:        position{line: 759, col: 18, offset: 23886},
 							val:        "",
 							ignoreCase: false,
 							want:       "\"\"",
@@ -15957,45 +15878,45 @@ var g = &grammar{
 		},
 		{
 			name: "NonEmptyUnionType",
-			pos:  position{line: 761, col: 1, offset: 23924},
+			pos:  position{line: 761, col: 1, offset: 23918},
 			expr: &actionExpr{
-				pos: position{line: 761, col: 21, offset: 23946},
+				pos: position{line: 761, col: 21, offset: 23940},
 				run: (*parser).callonNonEmptyUnionType1,
 				expr: &seqExpr{
-					pos: position{line: 761, col: 21, offset: 23946},
+					pos: position{line: 761, col: 21, offset: 23940},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 761, col: 21, offset: 23946},
+							pos:   position{line: 761, col: 21, offset: 23940},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 761, col: 27, offset: 23952},
+								pos:  position{line: 761, col: 27, offset: 23946},
 								name: "UnionTypeEntry",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 761, col: 42, offset: 23967},
+							pos:   position{line: 761, col: 42, offset: 23961},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 761, col: 47, offset: 23972},
+								pos: position{line: 761, col: 47, offset: 23966},
 								expr: &seqExpr{
-									pos: position{line: 761, col: 48, offset: 23973},
+									pos: position{line: 761, col: 48, offset: 23967},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 761, col: 48, offset: 23973},
+											pos:  position{line: 761, col: 48, offset: 23967},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 761, col: 50, offset: 23975},
+											pos:        position{line: 761, col: 50, offset: 23969},
 											val:        "|",
 											ignoreCase: false,
 											want:       "\"|\"",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 761, col: 54, offset: 23979},
+											pos:  position{line: 761, col: 54, offset: 23973},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 761, col: 56, offset: 23981},
+											pos:  position{line: 761, col: 56, offset: 23975},
 											name: "UnionTypeEntry",
 										},
 									},
@@ -16008,9 +15929,9 @@ var g = &grammar{
 		},
 		{
 			name: "UnionTypeEntry",
-			pos:  position{line: 786, col: 1, offset: 24824},
+			pos:  position{line: 786, col: 1, offset: 24818},
 			expr: &seqExpr{
-				pos: position{line: 786, col: 18, offset: 24843},
+				pos: position{line: 786, col: 18, offset: 24837},
 				exprs: []interface{}{
 					&choiceExpr{
 						pos: position{line: 154, col: 18, offset: 3799},
@@ -16385,26 +16306,26 @@ var g = &grammar{
 						},
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 786, col: 33, offset: 24858},
+						pos: position{line: 786, col: 33, offset: 24852},
 						expr: &seqExpr{
-							pos: position{line: 786, col: 34, offset: 24859},
+							pos: position{line: 786, col: 34, offset: 24853},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 786, col: 34, offset: 24859},
+									pos:  position{line: 786, col: 34, offset: 24853},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 786, col: 36, offset: 24861},
+									pos:        position{line: 786, col: 36, offset: 24855},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 786, col: 40, offset: 24865},
+									pos:  position{line: 786, col: 40, offset: 24859},
 									name: "_1",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 786, col: 43, offset: 24868},
+									pos:  position{line: 786, col: 43, offset: 24862},
 									name: "Expression",
 								},
 							},
@@ -16415,33 +16336,33 @@ var g = &grammar{
 		},
 		{
 			name: "MoreList",
-			pos:  position{line: 788, col: 1, offset: 24882},
+			pos:  position{line: 788, col: 1, offset: 24876},
 			expr: &actionExpr{
-				pos: position{line: 788, col: 12, offset: 24895},
+				pos: position{line: 788, col: 12, offset: 24889},
 				run: (*parser).callonMoreList1,
 				expr: &seqExpr{
-					pos: position{line: 788, col: 12, offset: 24895},
+					pos: position{line: 788, col: 12, offset: 24889},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 788, col: 12, offset: 24895},
+							pos:        position{line: 788, col: 12, offset: 24889},
 							val:        ",",
 							ignoreCase: false,
 							want:       "\",\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 788, col: 16, offset: 24899},
+							pos:  position{line: 788, col: 16, offset: 24893},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 788, col: 18, offset: 24901},
+							pos:   position{line: 788, col: 18, offset: 24895},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 788, col: 20, offset: 24903},
+								pos:  position{line: 788, col: 20, offset: 24897},
 								name: "Expression",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 788, col: 31, offset: 24914},
+							pos:  position{line: 788, col: 31, offset: 24908},
 							name: "_",
 						},
 					},
@@ -16450,66 +16371,66 @@ var g = &grammar{
 		},
 		{
 			name: "NonEmptyListLiteral",
-			pos:  position{line: 790, col: 1, offset: 24933},
+			pos:  position{line: 790, col: 1, offset: 24927},
 			expr: &actionExpr{
-				pos: position{line: 791, col: 7, offset: 24963},
+				pos: position{line: 791, col: 7, offset: 24957},
 				run: (*parser).callonNonEmptyListLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 791, col: 7, offset: 24963},
+					pos: position{line: 791, col: 7, offset: 24957},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 791, col: 7, offset: 24963},
+							pos:        position{line: 791, col: 7, offset: 24957},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 791, col: 11, offset: 24967},
+							pos:  position{line: 791, col: 11, offset: 24961},
 							name: "_",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 791, col: 13, offset: 24969},
+							pos: position{line: 791, col: 13, offset: 24963},
 							expr: &seqExpr{
-								pos: position{line: 791, col: 14, offset: 24970},
+								pos: position{line: 791, col: 14, offset: 24964},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 791, col: 14, offset: 24970},
+										pos:        position{line: 791, col: 14, offset: 24964},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 791, col: 18, offset: 24974},
+										pos:  position{line: 791, col: 18, offset: 24968},
 										name: "_",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 791, col: 22, offset: 24978},
+							pos:   position{line: 791, col: 22, offset: 24972},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 791, col: 28, offset: 24984},
+								pos:  position{line: 791, col: 28, offset: 24978},
 								name: "Expression",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 791, col: 39, offset: 24995},
+							pos:  position{line: 791, col: 39, offset: 24989},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 791, col: 41, offset: 24997},
+							pos:   position{line: 791, col: 41, offset: 24991},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 791, col: 46, offset: 25002},
+								pos: position{line: 791, col: 46, offset: 24996},
 								expr: &ruleRefExpr{
-									pos:  position{line: 791, col: 46, offset: 25002},
+									pos:  position{line: 791, col: 46, offset: 24996},
 									name: "MoreList",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 791, col: 56, offset: 25012},
+							pos:        position{line: 791, col: 56, offset: 25006},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -16520,27 +16441,27 @@ var g = &grammar{
 		},
 		{
 			name: "CompleteExpression",
-			pos:  position{line: 801, col: 1, offset: 25279},
+			pos:  position{line: 801, col: 1, offset: 25273},
 			expr: &actionExpr{
-				pos: position{line: 801, col: 22, offset: 25302},
+				pos: position{line: 801, col: 22, offset: 25296},
 				run: (*parser).callonCompleteExpression1,
 				expr: &seqExpr{
-					pos: position{line: 801, col: 22, offset: 25302},
+					pos: position{line: 801, col: 22, offset: 25296},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 801, col: 22, offset: 25302},
+							pos:  position{line: 801, col: 22, offset: 25296},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 801, col: 24, offset: 25304},
+							pos:   position{line: 801, col: 24, offset: 25298},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 801, col: 26, offset: 25306},
+								pos:  position{line: 801, col: 26, offset: 25300},
 								name: "Expression",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 801, col: 37, offset: 25317},
+							pos:  position{line: 801, col: 37, offset: 25311},
 							name: "_",
 						},
 					},
@@ -18109,46 +18030,6 @@ func (p *parser) callonHttp28() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHttp28()
-}
-
-func (c *current) onHttp64() (interface{}, error) {
-	return string(c.text), nil
-}
-
-func (p *parser) callonHttp64() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onHttp64()
-}
-
-func (c *current) onHttp60(u interface{}) (interface{}, error) {
-	return u, nil
-}
-
-func (p *parser) callonHttp60() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onHttp60(stack["u"])
-}
-
-func (c *current) onHttp71() (interface{}, error) {
-	return string(c.text), nil
-}
-
-func (p *parser) callonHttp71() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onHttp71()
-}
-
-func (c *current) onHttp67(q interface{}) (interface{}, error) {
-	return q, nil
-}
-
-func (p *parser) callonHttp67() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onHttp67(stack["q"])
 }
 
 func (c *current) onHttp4() (interface{}, error) {

--- a/parser/internal/dhall.peg
+++ b/parser/internal/dhall.peg
@@ -402,9 +402,9 @@ AbsolutePath ← p:Path { return LocalFile(path.Join("/", p.(string))), nil }
 
 Scheme ← "http" 's'?
 
-HttpRaw ← Scheme "://" Authority UrlPath ( '?' Query )? { return url.ParseRequestURI(string(c.text)) }
+HttpRaw ← Scheme "://" Authority path_abempty ( '?' Query )? { return url.ParseRequestURI(string(c.text)) }
 
-UrlPath ← (PathComponent / '/' Segment)*
+path_abempty ← ('/' Segment)*
 
 Authority ← (Userinfo '@')? Host (':' Port)?
 

--- a/spec_test.go
+++ b/spec_test.go
@@ -44,10 +44,6 @@ var expectedFailures = []string{
 	"TestBinaryDecode/unit/IntegerBigPositive",
 	"TestBinaryDecode/unit/NaturalBig",
 
-	// needs quoted paths in URLs
-	"TestParserAccepts/unit/import/quotedPaths",     // needs.. quoted paths
-	"TestParserAccepts/unit/import/urls/quotedPath", // needs quotedPaths
-
 	// urgh IEEE floating point; NaN != NaN :(
 	"TestTypeInference/unit/AssertNaNA",
 


### PR DESCRIPTION
The PEG grammer would parse quoted paths but I never implemented support
to deal with the quoted path segments properly anyway.

This commit removes support for quoted paths and verifies that the
changed upstream tests pass.