### PR TITLE
Add git submodule instructions in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ vendoring of dependencies is required.
 
 ### Running the tests
 
+    git submodule update --init --recursive
+
     go test ./...
 
     go test -short ./... # skips long-running tests


### PR DESCRIPTION
I was wondering why I always got segfaults in `go test ./...`. Spotted.