### PR TITLE
Fix import tests on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+imports/testdata/just_text.txt text eol=lf


### PR DESCRIPTION
Fixes #42, hopefully.  On Windows, this file was getting checked out of
git with crlf endings, but the test asserted it had lf line endings.  I
think the simplest fix is to specify that this one file has lf endings
in git.