### PR TITLE
Fix import tests on Windows

### DIFF
--- a/imports/imports_test.go
+++ b/imports/imports_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"runtime"
 
 	. "github.com/philandstuff/dhall-golang/v3/imports"
 	. "github.com/philandstuff/dhall-golang/v3/internal"
@@ -183,7 +184,11 @@ var _ = Describe("Import resolution", func() {
 			actual, err := Load(NewLocalImport("./testdata/just_text.txt", RawText))
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(actual).To(Equal(PlainText("here is some text\n")))
+			if runtime.GOOS == "windows" {
+				Expect(actual).To(Equal(PlainText("here is some text\r\n")))
+			} else {
+				Expect(actual).To(Equal(PlainText("here is some text\n")))
+			}
 		})
 		It("Resolves as code", func() {
 			actual, err := Load(NewLocalImport("./testdata/natural.dhall", Code))


### PR DESCRIPTION
Fixes #42, hopefully.  On Windows, this file was getting checked out of
git with crlf endings, but the test asserted it had lf line endings.

This makes the test use the appropriate line ending for the OS.  It's a
hacky fix but it will do, I suppose.