### PR TITLE
Allow abstract `toMap x` to be evaled

### DIFF
--- a/core/eval.go
+++ b/core/eval.go
@@ -416,10 +416,11 @@ func evalWith(t term.Term, e env) Value {
 			}
 			return result
 		}
-		return toMap{
-			Record: record,
-			Type:   evalWith(t.Type, e),
+		toMapVal := toMap{Record: recordVal}
+		if t.Type != nil {
+			toMapVal.Type = evalWith(t.Type, e)
 		}
+		return toMapVal
 	case term.Field:
 		record := evalWith(t.Record, e)
 		for { // simplifications

--- a/core/eval_test.go
+++ b/core/eval_test.go
@@ -38,4 +38,14 @@ var _ = Describe("Eval", func() {
 				To(Equal(Type))
 		})
 	})
+	Describe("toMap", func() {
+		It("Evaluates with missing type and abstract value", func() {
+			Expect(Eval(term.ToMap{
+				Record: term.Var{Name: "x"},
+			})).
+				To(Equal(toMap{
+					Record: freeVar{Name: "x"},
+				}))
+		})
+	})
 })


### PR DESCRIPTION
Two problems:

 - need to use abstract `recordVal` not concrete `record`
 - should only evaluate the type if it is present

Fixes #48.