### PR TITLE
Update go.mod and imports to v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/philandstuff/dhall-golang/v5"
+	"github.com/philandstuff/dhall-golang/v6"
 )
 
 // Config can be a fairly arbitrary Go datatype.  You would put your

--- a/binary/cbor.go
+++ b/binary/cbor.go
@@ -8,7 +8,7 @@ import (
 	"path"
 
 	"github.com/fxamacker/cbor/v2"
-	. "github.com/philandstuff/dhall-golang/v5/term"
+	. "github.com/philandstuff/dhall-golang/v6/term"
 )
 
 var nameToBuiltin = map[string]Term{

--- a/binary/performance_test.go
+++ b/binary/performance_test.go
@@ -7,11 +7,11 @@ import (
 	"path"
 	"testing"
 
-	"github.com/philandstuff/dhall-golang/v5/binary"
-	"github.com/philandstuff/dhall-golang/v5/core"
-	"github.com/philandstuff/dhall-golang/v5/imports"
-	"github.com/philandstuff/dhall-golang/v5/internal"
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/binary"
+	"github.com/philandstuff/dhall-golang/v6/core"
+	"github.com/philandstuff/dhall-golang/v6/imports"
+	"github.com/philandstuff/dhall-golang/v6/internal"
+	"github.com/philandstuff/dhall-golang/v6/term"
 )
 
 func BenchmarkDecodeLargeExpression(b *testing.B) {

--- a/binary/semantic_hash.go
+++ b/binary/semantic_hash.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 
-	"github.com/philandstuff/dhall-golang/v5/core"
+	"github.com/philandstuff/dhall-golang/v6/core"
 )
 
 // SemanticHash returns the semantic hash of an evaluated expression.

--- a/cmd/json.go
+++ b/cmd/json.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/philandstuff/dhall-golang/v5"
+	"github.com/philandstuff/dhall-golang/v6"
 	"github.com/urfave/cli/v2" // imports as package "cli"
 )
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,10 +6,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/philandstuff/dhall-golang/v5/binary"
-	"github.com/philandstuff/dhall-golang/v5/core"
-	"github.com/philandstuff/dhall-golang/v5/imports"
-	"github.com/philandstuff/dhall-golang/v5/parser"
+	"github.com/philandstuff/dhall-golang/v6/binary"
+	"github.com/philandstuff/dhall-golang/v6/core"
+	"github.com/philandstuff/dhall-golang/v6/imports"
+	"github.com/philandstuff/dhall-golang/v6/parser"
 	"github.com/urfave/cli/v2" // imports as package "cli"
 )
 

--- a/cmd/yaml.go
+++ b/cmd/yaml.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/philandstuff/dhall-golang/v5"
+	"github.com/philandstuff/dhall-golang/v6"
 	"github.com/urfave/cli/v2" // imports as package "cli"
 	"gopkg.in/yaml.v2"
 )

--- a/core/ast.go
+++ b/core/ast.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/term"
 )
 
 // A Value is a Dhall value in beta-normal form.  You can think of

--- a/core/builtins.go
+++ b/core/builtins.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/term"
 )
 
 func (naturalBuild) Call(x Value) Value {

--- a/core/builtins_test.go
+++ b/core/builtins_test.go
@@ -3,8 +3,8 @@ package core_test
 import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"github.com/philandstuff/dhall-golang/v5/core"
-	"github.com/philandstuff/dhall-golang/v5/parser"
+	"github.com/philandstuff/dhall-golang/v6/core"
+	"github.com/philandstuff/dhall-golang/v6/parser"
 )
 
 var _ = DescribeTable("ArgType of builtins", func(src, typ string) {

--- a/core/equivalence_test.go
+++ b/core/equivalence_test.go
@@ -5,7 +5,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/term"
 )
 
 // Ensure that alphaMatcher is a valid GomegaMatcher

--- a/core/eval.go
+++ b/core/eval.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/term"
 )
 
 type env map[string][]Value

--- a/core/eval_test.go
+++ b/core/eval_test.go
@@ -3,7 +3,7 @@ package core
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/term"
 )
 
 var _ = Describe("Eval", func() {

--- a/core/quote.go
+++ b/core/quote.go
@@ -3,7 +3,7 @@ package core
 import (
 	"fmt"
 
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/term"
 )
 
 // Quote takes the Value v and turns it back into a Term.

--- a/core/quote_test.go
+++ b/core/quote_test.go
@@ -3,7 +3,7 @@ package core
 import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/term"
 )
 
 var _ = DescribeTable("Quote",

--- a/core/testing.go
+++ b/core/testing.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/term"
 )
 
 // GomegaMatcher is a copy of

--- a/core/typecheck.go
+++ b/core/typecheck.go
@@ -3,7 +3,7 @@ package core
 import (
 	"fmt"
 
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/term"
 )
 
 type context map[string][]Value

--- a/core/typecheck_test.go
+++ b/core/typecheck_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/term"
 )
 
 var _ = DescribeTable("functionCheck",

--- a/example_function_test.go
+++ b/example_function_test.go
@@ -3,7 +3,7 @@ package dhall_test
 import (
 	"fmt"
 
-	"github.com/philandstuff/dhall-golang/v5"
+	"github.com/philandstuff/dhall-golang/v6"
 )
 
 // Config is the struct we want to unmarshal from Dhall

--- a/example_nested_test.go
+++ b/example_nested_test.go
@@ -3,7 +3,7 @@ package dhall_test
 import (
 	"fmt"
 
-	"github.com/philandstuff/dhall-golang/v5"
+	"github.com/philandstuff/dhall-golang/v6"
 )
 
 // NestedConfig is the struct we want to unmarshal from Dhall

--- a/example_tagged_test.go
+++ b/example_tagged_test.go
@@ -3,7 +3,7 @@ package dhall_test
 import (
 	"fmt"
 
-	"github.com/philandstuff/dhall-golang/v5"
+	"github.com/philandstuff/dhall-golang/v6"
 )
 
 // TaggedMessage is the struct we want to unmarshal from Dhall

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,7 @@ package dhall_test
 import (
 	"fmt"
 
-	"github.com/philandstuff/dhall-golang/v5"
+	"github.com/philandstuff/dhall-golang/v6"
 )
 
 // Message is the struct we want to unmarshal from Dhall

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/philandstuff/dhall-golang/v5
+module github.com/philandstuff/dhall-golang/v6
 
 require (
 	github.com/fxamacker/cbor/v2 v2.2.1-0.20200511212021-28e39be4a84f

--- a/imports/cache.go
+++ b/imports/cache.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"path"
 
-	"github.com/philandstuff/dhall-golang/v5/binary"
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/binary"
+	"github.com/philandstuff/dhall-golang/v6/term"
 )
 
 // DhallCache is an interface for caching implementations.

--- a/imports/imports.go
+++ b/imports/imports.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/philandstuff/dhall-golang/v5/binary"
-	"github.com/philandstuff/dhall-golang/v5/core"
-	"github.com/philandstuff/dhall-golang/v5/parser"
-	"github.com/philandstuff/dhall-golang/v5/term"
-	. "github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/binary"
+	"github.com/philandstuff/dhall-golang/v6/core"
+	"github.com/philandstuff/dhall-golang/v6/parser"
+	"github.com/philandstuff/dhall-golang/v6/term"
+	. "github.com/philandstuff/dhall-golang/v6/term"
 )
 
 // Load takes a Term and resolves all imports

--- a/imports/imports_test.go
+++ b/imports/imports_test.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"os"
 
-	. "github.com/philandstuff/dhall-golang/v5/imports"
-	. "github.com/philandstuff/dhall-golang/v5/internal"
-	. "github.com/philandstuff/dhall-golang/v5/term"
+	. "github.com/philandstuff/dhall-golang/v6/imports"
+	. "github.com/philandstuff/dhall-golang/v6/internal"
+	. "github.com/philandstuff/dhall-golang/v6/term"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/internal/gubbins.go
+++ b/internal/gubbins.go
@@ -10,7 +10,7 @@ package internal
 import (
 	"net/url"
 
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/term"
 )
 
 func NewImport(fetchable term.Fetchable, mode term.ImportMode) term.Import {

--- a/parser/internal/dhall.go
+++ b/parser/internal/dhall.go
@@ -21,7 +21,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	. "github.com/philandstuff/dhall-golang/v5/term"
+	. "github.com/philandstuff/dhall-golang/v6/term"
 )
 
 // Helper function for parsing all the operator parsing blocks

--- a/parser/internal/dhall.peg
+++ b/parser/internal/dhall.peg
@@ -29,7 +29,7 @@ import (
 "unicode"
 "unicode/utf8"
 )
-import . "github.com/philandstuff/dhall-golang/v5/term"
+import . "github.com/philandstuff/dhall-golang/v6/term"
 
 // Helper function for parsing all the operator parsing blocks
 // see OrExpression for an example of how this is used

--- a/parser/internal/multiline.go
+++ b/parser/internal/multiline.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"strings"
 
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/term"
 )
 
 // removeLeadingCommonIndent removes the common leading indent from a

--- a/parser/internal/multiline_test.go
+++ b/parser/internal/multiline_test.go
@@ -1,7 +1,7 @@
 package internal
 
 import (
-	. "github.com/philandstuff/dhall-golang/v5/term"
+	. "github.com/philandstuff/dhall-golang/v6/term"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"io"
 
-	"github.com/philandstuff/dhall-golang/v5/parser/internal"
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/parser/internal"
+	"github.com/philandstuff/dhall-golang/v6/term"
 )
 
 //go:generate pigeon -optimize-grammar -optimize-parser -o internal/dhall.go internal/dhall.peg

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -3,9 +3,9 @@ package parser_test
 import (
 	"math"
 
-	. "github.com/philandstuff/dhall-golang/v5/internal"
-	"github.com/philandstuff/dhall-golang/v5/parser"
-	. "github.com/philandstuff/dhall-golang/v5/term"
+	. "github.com/philandstuff/dhall-golang/v6/internal"
+	"github.com/philandstuff/dhall-golang/v6/parser"
+	. "github.com/philandstuff/dhall-golang/v6/term"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"

--- a/property_test.go
+++ b/property_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/leanovate/gopter/gen"
 	"github.com/leanovate/gopter/prop"
 
-	"github.com/philandstuff/dhall-golang/v5/core"
-	"github.com/philandstuff/dhall-golang/v5/parser"
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/core"
+	"github.com/philandstuff/dhall-golang/v6/parser"
+	"github.com/philandstuff/dhall-golang/v6/term"
 )
 
 var (

--- a/regression_test.go
+++ b/regression_test.go
@@ -4,8 +4,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	. "github.com/philandstuff/dhall-golang/v5/core"
-	"github.com/philandstuff/dhall-golang/v5/parser"
+	. "github.com/philandstuff/dhall-golang/v6/core"
+	"github.com/philandstuff/dhall-golang/v6/parser"
 )
 
 func parseAndTypecheckTest(source string, expectedTypeSource string) {

--- a/spec_test.go
+++ b/spec_test.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/philandstuff/dhall-golang/v5/binary"
-	"github.com/philandstuff/dhall-golang/v5/core"
-	"github.com/philandstuff/dhall-golang/v5/imports"
-	"github.com/philandstuff/dhall-golang/v5/parser"
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/binary"
+	"github.com/philandstuff/dhall-golang/v6/core"
+	"github.com/philandstuff/dhall-golang/v6/imports"
+	"github.com/philandstuff/dhall-golang/v6/parser"
+	"github.com/philandstuff/dhall-golang/v6/term"
 	"github.com/pkg/errors"
 )
 

--- a/term/fetchable_test.go
+++ b/term/fetchable_test.go
@@ -6,8 +6,8 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/philandstuff/dhall-golang/v5/internal"
-	. "github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/internal"
+	. "github.com/philandstuff/dhall-golang/v6/term"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -6,10 +6,10 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/philandstuff/dhall-golang/v5/core"
-	"github.com/philandstuff/dhall-golang/v5/imports"
-	"github.com/philandstuff/dhall-golang/v5/parser"
-	"github.com/philandstuff/dhall-golang/v5/term"
+	"github.com/philandstuff/dhall-golang/v6/core"
+	"github.com/philandstuff/dhall-golang/v6/imports"
+	"github.com/philandstuff/dhall-golang/v6/parser"
+	"github.com/philandstuff/dhall-golang/v6/term"
 )
 
 func isMapEntryType(recordType map[string]core.Value) bool {

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -3,9 +3,9 @@ package dhall_test
 import (
 	"reflect"
 
-	. "github.com/philandstuff/dhall-golang/v5"
-	"github.com/philandstuff/dhall-golang/v5/core"
-	"github.com/philandstuff/dhall-golang/v5/term"
+	. "github.com/philandstuff/dhall-golang/v6"
+	"github.com/philandstuff/dhall-golang/v6/core"
+	"github.com/philandstuff/dhall-golang/v6/term"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"


### PR DESCRIPTION
I was trying to use 6.0.0 in my go module, but unfortunately go presented me with the following message:

```
go: github.com/philandstuff/dhall-golang/v6@v6.0.0: go.mod has non-.../v6 module path "github.com/philandstuff/dhall-golang/v5" (and .../v6/go.mod does not exist) at revision v6.0.0
```

This merge request should fix it (for future releases).